### PR TITLE
EG-330: Added error handling and refactored code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,91 @@ This code is open source software licensed under the [Apache 2.0 License]("http:
 
 ## Endpoints
 
-### `/external-guidance/scratch`
+### `POST: /external-guidance/scratch`
 
 #### Success Response
 
 **HTTP Status**: `201`
 
-**Example HTTP Response Body**:
+**Example Response Body**:
 ```
 {
    "id": "265e0178-cbe1-42ab-8418-7120ce6d0925"
 }
 ```
+
+#### Error Responses
+
+**Error response format**
+```
+{
+   "code": "ERROR_CODE",
+   "message": "Human readable error message"
+}
+```
+
+<table>
+    <thead>
+        <tr>
+            <th>HTTP Status</th>
+            <th>Error Code</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><pre>400</pre></td>
+            <td><pre>BAD_REQUEST</pre></td>
+        </tr>
+        <tr>
+            <td><pre>500</pre></td>
+            <td><pre>INTERNAL_SERVER_ERROR</pre></td>
+        </tr>
+    </tbody>
+</table>
+
+### `GET: /external-guidance/scratch/:id`
+
+#### `id` Parameter
+
+The `id` parameter is an`UUID` formatted string e.g. `bf8bf6bb-0894-4df6-8209-2467bc9af6ae`
+
+#### Success Response
+
+**HTTP Status**: `200`
+
+**Response Body**
+
+Represents a valid guidance flow in JSON format.
+
+#### Error Responses
+
+**Error response format**
+```
+{
+   "code": "ERROR_CODE",
+   "message": "Human readable error message"
+}
+```
+
+<table>
+    <thead>
+        <tr>
+            <th>HTTP Status</th>
+            <th>Error Code</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><pre>400</pre></td>
+            <td><pre>BAD_REQUEST</pre></td>
+        </tr>
+        <tr>
+            <td><pre>404</pre></td>
+            <td><pre>NOT_FOUND_ERROR</pre></td>
+        </tr>
+        <tr>
+            <td><pre>500</pre></td>
+            <td><pre>INTERNAL_SERVER_ERROR</pre></td>
+        </tr>
+    </tbody>
+</table>

--- a/app/controllers/ScratchController.scala
+++ b/app/controllers/ScratchController.scala
@@ -16,35 +16,34 @@
 
 package controllers
 
-import java.util.UUID
 import javax.inject.{Inject, Singleton}
+import models.errors.{BadRequestError, Errors, InternalServiceError, NotFoundError}
 import play.api.libs.json.{JsObject, JsValue, Json}
-import play.api.mvc.{Action, ControllerComponents, AnyContent}
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.ScratchService
 import uk.gov.hmrc.play.bootstrap.controller.BackendController
-import scala.concurrent.Future
+
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{Try,Success,Failure}
 
 @Singleton()
 class ScratchController @Inject() (scratchService: ScratchService, cc: ControllerComponents) extends BackendController(cc) {
 
   def save(): Action[JsValue] = Action.async(parse.json) { implicit request =>
     val process = request.body.as[JsObject]
-    scratchService.save(process).map { id =>
-      Created(Json.obj("id" -> id.toString))
+
+    scratchService.save(process).map {
+      case Right(id) => Created(Json.obj("id" -> id.toString))
+      case Left(Errors(BadRequestError :: Nil)) => BadRequest(Json.toJson(BadRequestError))
+      case Left(_) => InternalServerError(Json.toJson(InternalServiceError))
     }
   }
 
-  def get(uuidString: String): Action[AnyContent] = Action.async { _ =>
-    Try{UUID.fromString(uuidString)} match {
-      case Success(uuid) =>
-        scratchService.getByUuid(uuid).map {
-          case Some(jsObject) => Ok(jsObject)
-          case None => NotFound
-        }
-      case Failure(_) => Future.successful(NotFound)
+  def get(id: String): Action[AnyContent] = Action.async { _ =>
+    scratchService.getById(id).map {
+      case Right(process) => Ok(process)
+      case Left(Errors(NotFoundError :: Nil)) => NotFound(Json.toJson(NotFoundError))
+      case Left(Errors(BadRequestError :: Nil)) => BadRequest(Json.toJson(BadRequestError))
+      case Left(_) => InternalServerError(Json.toJson(InternalServiceError))
     }
   }
-
 }

--- a/app/models/errors/Error.scala
+++ b/app/models/errors/Error.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.errors
+
+import play.api.libs.json._
+
+case class Error(code: String, message: String)
+
+object Error {
+  implicit val writes: Writes[Error] = Json.writes[Error]
+}
+
+object InternalServiceError
+    extends Error(
+      "INTERNAL_SERVER_ERROR",
+      "An error occurred whilst processing your request."
+    )
+
+object DatabaseError
+    extends Error(
+      "DATABASE_ERROR",
+      "An error occurred whilst accessing the database."
+    )
+
+object NotFoundError
+    extends Error(
+      "NOT_FOUND_ERROR",
+      "The resource requested could not be found."
+    )
+
+object BadRequestError extends Error("BAD_REQUEST", "The request is invalid.")

--- a/app/models/errors/Errors.scala
+++ b/app/models/errors/Errors.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.errors
+
+import play.api.libs.json.{Json, Writes}
+
+case class Errors(errors: Seq[Error])
+
+object Errors {
+  def apply(error: Error): Errors = Errors(Seq(error))
+
+  implicit val writes: Writes[Errors] = (data: Errors) => {
+    if (data.errors.size > 1) {
+      Json.obj("errors" -> Json.toJson(data.errors))
+    } else {
+      Json.toJson(data.errors.head)
+    }
+  }
+}

--- a/app/models/package.scala
+++ b/app/models/package.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import models.errors.Errors
+
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package object models {
+  type RequestOutcome[T] = Either[Errors, T]
+}

--- a/app/utils/Validators.scala
+++ b/app/utils/Validators.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import java.util.UUID
+
+object Validators {
+
+  def validateUUID(id: String): Option[UUID] = {
+    val format = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    if (id.matches(format)) Some(UUID.fromString(id)) else None
+  }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,4 +1,4 @@
 # microservice specific routes
 
-GET         /scratch/$uuid<[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}>   controllers.ScratchController.get(uuid: String)
-POST        /scratch         																			  controllers.ScratchController.save
+GET         /scratch/:id        controllers.ScratchController.get(id)
+POST        /scratch            controllers.ScratchController.save

--- a/it/endpoints/GetScratchProcessISpec.scala
+++ b/it/endpoints/GetScratchProcessISpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package endpoints
+
+import java.util.UUID
+
+import data.ExamplePayloads
+import play.api.http.{ContentTypes, Status}
+import play.api.libs.json.{JsObject, JsValue}
+import play.api.libs.ws.WSResponse
+import stubs.AuditStub
+import support.IntegrationSpec
+
+class GetScratchProcessISpec extends IntegrationSpec {
+
+  "Calling the scratch GET endpoint with a valid ID" should {
+
+    def populateDatabase(): String = {
+      lazy val request = buildRequest("/external-guidance/scratch")
+      val result = await(request.post(ExamplePayloads.simpleValidProcess))
+      val json = result.body[JsValue].as[JsObject]
+      (json \ "id").as[String]
+    }
+
+    lazy val id = populateDatabase()
+    lazy val request = buildRequest(s"/external-guidance/scratch/$id")
+    lazy val response: WSResponse = {
+      AuditStub.audit()
+      await(request.get())
+    }
+
+    "return a OK status code" in {
+      response.status shouldBe Status.OK
+    }
+
+    "return content as JSON" in {
+      response.contentType shouldBe ContentTypes.JSON
+    }
+
+    "return the corresponding JSON in the response" in {
+      val json = response.body[JsValue].as[JsObject]
+      json shouldBe ExamplePayloads.simpleValidProcess
+    }
+  }
+
+  "Calling the scratch GET endpoint with a unknown ID" should {
+
+    lazy val id = UUID.randomUUID().toString
+    lazy val request = buildRequest(s"/external-guidance/scratch/$id")
+    lazy val response: WSResponse = {
+      AuditStub.audit()
+      await(request.get())
+    }
+
+    "return a not found status code" in {
+      response.status shouldBe Status.NOT_FOUND
+    }
+
+    "return content as JSON" in {
+      response.contentType shouldBe ContentTypes.JSON
+    }
+
+    "return the not found error response" in {
+      val json = response.body[JsValue].as[JsObject]
+      (json \ "code").as[String] shouldBe "NOT_FOUND_ERROR"
+    }
+  }
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,17 +5,14 @@ object AppDependencies {
 
   val compile = Seq(
     "uk.gov.hmrc" %% "govuk-template" % "5.45.0-play-26",
-    "uk.gov.hmrc" %% "play-ui" % "8.4.0-play-26",
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.3.0",
-    "uk.gov.hmrc" %% "simple-reactivemongo" % "7.23.0-play-26"
+    "uk.gov.hmrc" %% "play-ui" % "8.8.0-play-26",
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.5.0",
+    "uk.gov.hmrc" %% "simple-reactivemongo" % "7.26.0-play-26"
   )
 
   val test = Seq(
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.3.0" % Test classifier "tests",
-    "uk.gov.hmrc" %% "reactivemongo-test" % "4.16.0-play-26" % "test, it",
     "org.scalamock" %% "scalamock" % "4.4.0" % "test",
     "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-    "org.jsoup" % "jsoup" % "1.10.2" % "test",
     "com.typesafe.play" %% "play-test" % current % "test",
     "org.pegdown" % "pegdown" % "1.6.0" % "test, it",
     "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % "test, it",

--- a/test/base/UnitSpec.scala
+++ b/test/base/UnitSpec.scala
@@ -17,10 +17,10 @@
 package base
 
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.{Matchers, WordSpec}
 import play.api.libs.json._
 
-trait BaseSpec extends WordSpec with MustMatchers with ScalaFutures {
+trait UnitSpec extends WordSpec with Matchers with ScalaFutures {
 
   def missingJsObjectAttrTests[T](jsObject: JsObject, attrsToIgnore: List[String] = Nil)(implicit objectReads: Reads[T]): Unit =
     jsObject.keys.filterNot(attrsToIgnore.contains(_)).foreach { attributeName =>

--- a/test/controllers/ScratchControllerSpec.scala
+++ b/test/controllers/ScratchControllerSpec.scala
@@ -200,7 +200,6 @@ class ScratchControllerSpec extends WordSpec with Matchers with ScalaFutures wit
 
       trait ErrorGetTest extends Test {
         val expectedErrorCode = "INTERNAL_SERVER_ERROR"
-        val process: JsObject = Json.obj()
         MockScratchService.getById(id).returns(Future.successful(Left(Errors(InternalServiceError))))
         lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
       }

--- a/test/mocks/MockScratchRepository.scala
+++ b/test/mocks/MockScratchRepository.scala
@@ -18,6 +18,7 @@ package mocks
 
 import java.util.UUID
 
+import models.RequestOutcome
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import play.api.libs.json.JsObject
@@ -30,16 +31,16 @@ trait MockScratchRepository extends MockFactory {
 
   object MockScratchRepository {
 
-    def save(process: JsObject): CallHandler[Future[UUID]] = {
+    def save(process: JsObject): CallHandler[Future[RequestOutcome[UUID]]] = {
       (mockScratchRepository
         .save(_: JsObject))
         .expects(process)
     }
 
-    def getByUuid(uuid: UUID): CallHandler[Future[Option[JsObject]]] = {
+    def getById(id: UUID): CallHandler[Future[RequestOutcome[JsObject]]] = {
       (mockScratchRepository
-        .getByUuid(_: UUID))
-        .expects(uuid)
+        .getById(_: UUID))
+        .expects(where[UUID](_.toString == id.toString))
     }
 
   }

--- a/test/mocks/MockScratchService.scala
+++ b/test/mocks/MockScratchService.scala
@@ -18,6 +18,7 @@ package mocks
 
 import java.util.UUID
 
+import models.RequestOutcome
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import play.api.libs.json.JsObject
@@ -30,16 +31,16 @@ trait MockScratchService extends MockFactory {
 
   object MockScratchService {
 
-    def save(): CallHandler[Future[UUID]] = {
+    def save(scratch: JsObject): CallHandler[Future[RequestOutcome[UUID]]] = {
       (mockScratchService
         .save(_: JsObject))
-        .expects(*)
+        .expects(scratch)
     }
 
-    def getByUuid(uuid: UUID): CallHandler[Future[Option[JsObject]]] = {
+    def getById(id: String): CallHandler[Future[RequestOutcome[JsObject]]] = {
       (mockScratchService
-        .getByUuid(_: UUID))
-        .expects(uuid)
+        .getById(_: String))
+        .expects(id)
     }
 
   }

--- a/test/models/errors/ErrorsSpec.scala
+++ b/test/models/errors/ErrorsSpec.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.errors
+
+import base.UnitSpec
+import play.api.libs.json.Json
+
+class ErrorsSpec extends UnitSpec {
+
+  "Serialising a single error into JSON" should {
+    "generate the correct JSON" in {
+      val expected = Json.parse(
+        """
+          |{
+          |  "code": "SOME_CODE",
+          |  "message": "some message"
+          |}
+        """.stripMargin
+      )
+
+      val error = Errors(Error("SOME_CODE", "some message"))
+
+      val result = Json.toJson(error)
+
+      result shouldBe expected
+    }
+  }
+
+  "Serialising multiple errors into JSON" should {
+    "generate the correct JSON" in {
+      val expected = Json.parse(
+        """
+          |{
+          |  "errors": [
+          |    {
+          |      "code": "SOME_CODE_1",
+          |      "message": "some message 1"
+          |    },
+          |    {
+          |      "code": "SOME_CODE_2",
+          |      "message": "some message 2"
+          |    }
+          |  ]
+          |}
+        """.stripMargin
+      )
+
+      val errors = Errors(
+        Seq(
+          Error("SOME_CODE_1", "some message 1"),
+          Error("SOME_CODE_2", "some message 2")
+        )
+      )
+
+      val result = Json.toJson(errors)
+
+      result shouldBe expected
+    }
+  }
+}

--- a/test/models/ocelot/LinkSpec.scala
+++ b/test/models/ocelot/LinkSpec.scala
@@ -16,10 +16,10 @@
 
 package models.ocelot
 
-import base.BaseSpec
+import base.UnitSpec
 import play.api.libs.json._
 
-class LinkSpec extends BaseSpec {
+class LinkSpec extends UnitSpec {
 
   val id1 = 0
   val dest1 = "http://www.bbc.co.uk/news"
@@ -69,9 +69,9 @@ class LinkSpec extends BaseSpec {
   "Link" must {
     "deserialise from json" in {
 
-      link1Json.as[Link] mustBe link1
+      link1Json.as[Link] shouldBe link1
 
-      link2Json.as[Link] mustBe link2
+      link2Json.as[Link] shouldBe link2
     }
 
     missingJsObjectAttrTests[Link](link1Json, List("popup", "always", "leftbar"))
@@ -81,7 +81,7 @@ class LinkSpec extends BaseSpec {
 
     "deserialise from links section json" in {
 
-      Json.parse(linksStr).as[Vector[Link]] mustBe Vector(link1, link2)
+      Json.parse(linksStr).as[Vector[Link]] shouldBe Vector(link1, link2)
 
     }
 

--- a/test/models/ocelot/MetaSpec.scala
+++ b/test/models/ocelot/MetaSpec.scala
@@ -16,10 +16,10 @@
 
 package models.ocelot
 
-import base.BaseSpec
+import base.UnitSpec
 import play.api.libs.json._
 
-class MetaSpec extends BaseSpec {
+class MetaSpec extends UnitSpec {
 
   val title = "Process title"
   val id = "abc90001"
@@ -51,7 +51,7 @@ class MetaSpec extends BaseSpec {
 
     "deserialise correctly" in {
       val result: Meta = validJson.as[Meta]
-      result mustBe validModel
+      result shouldBe validModel
     }
 
     missingJsObjectAttrTests[Meta](validJson)

--- a/test/models/ocelot/PhraseSpec.scala
+++ b/test/models/ocelot/PhraseSpec.scala
@@ -16,10 +16,10 @@
 
 package models.ocelot
 
-import org.scalatestplus.play.PlaySpec
+import base.UnitSpec
 import play.api.libs.json._
 
-class PhraseSpec extends PlaySpec with ProcessJson {
+class PhraseSpec extends UnitSpec with ProcessJson {
 
   val p1 = "Ask the customer if they have a tea bag"
   val p1w = "Welsh, Ask the customer if they have a tea bag"
@@ -34,9 +34,9 @@ class PhraseSpec extends PlaySpec with ProcessJson {
 
   "Phrase" must {
     "deserialise " in {
-      Json.parse(phrase1).as[Phrase] mustBe Phrase(Vector(p1, p1w))
-      Json.parse(phrase2).as[Phrase] mustBe Phrase(Vector(p2, p2w))
-      Json.parse(phrase3).as[Phrase] mustBe Phrase(Vector(p3, p3w))
+      Json.parse(phrase1).as[Phrase] shouldBe Phrase(Vector(p1, p1w))
+      Json.parse(phrase2).as[Phrase] shouldBe Phrase(Vector(p2, p2w))
+      Json.parse(phrase3).as[Phrase] shouldBe Phrase(Vector(p3, p3w))
     }
   }
 
@@ -44,7 +44,7 @@ class PhraseSpec extends PlaySpec with ProcessJson {
 
     "deserialise from phrases section json" in {
 
-      Json.parse(s"""[ $phrase1, $phrase2, $phrase3 ]""").as[Vector[Phrase]] mustBe
+      Json.parse(s"""[ $phrase1, $phrase2, $phrase3 ]""").as[Vector[Phrase]] shouldBe
         Vector(Phrase(Vector(p1, p1w)), Phrase(Vector(p2, p2w)), Phrase(Vector(p3, p3w)))
 
     }
@@ -55,7 +55,7 @@ class PhraseSpec extends PlaySpec with ProcessJson {
       val thirdPhraseIndex = 2
       val welshLangIndex = 1
 
-      protoTypePhrases(thirdPhraseIndex).langs(welshLangIndex) mustBe "Welsh: Overview"
+      protoTypePhrases(thirdPhraseIndex).langs(welshLangIndex) shouldBe "Welsh: Overview"
     }
 
   }

--- a/test/models/ocelot/ProcessJson.scala
+++ b/test/models/ocelot/ProcessJson.scala
@@ -18,9 +18,6 @@ package models.ocelot
 
 import play.api.libs.json.{JsValue, Json, JsObject}
 
-//
-// All Welsh translations are temporary placeholders and for testing purposes only
-//
 trait ProcessJson {
 
   val validOnePageJson: JsValue = Json.parse(
@@ -85,7 +82,6 @@ trait ProcessJson {
     """.stripMargin
   )
 
-  // Ocelot Prototype process demonstrating range of Stanzas and range of relevant Stanza attributes
   val prototypeMetaSection: String =
     """
     |  {

--- a/test/models/ocelot/ProcessSpec.scala
+++ b/test/models/ocelot/ProcessSpec.scala
@@ -16,11 +16,11 @@
 
 package models.ocelot
 
-import base.BaseSpec
+import base.UnitSpec
 import play.api.libs.json._
 import models.ocelot.stanzas.Stanza
 
-class ProcessSpec extends BaseSpec with ProcessJson {
+class ProcessSpec extends UnitSpec with ProcessJson {
 
   val ten: Int = 10
   val oneHundred: Int = 100
@@ -36,10 +36,10 @@ class ProcessSpec extends BaseSpec with ProcessJson {
 
     "Deserialise from prototype json" in {
 
-      process.meta mustBe meta
-      process.flow mustBe flow
-      process.phrases mustBe phrases
-      process.links mustBe links
+      process.meta shouldBe meta
+      process.flow shouldBe flow
+      process.phrases shouldBe phrases
+      process.links shouldBe links
 
     }
 
@@ -52,12 +52,12 @@ class ProcessSpec extends BaseSpec with ProcessJson {
     "Return phrase valid index" in {
 
       val phrase = Phrase(Vector("Telling HMRC about extra income", "Welsh: Telling HMRC about extra income"))
-      process.phraseOption(0) mustBe Some(phrase)
+      process.phraseOption(0) shouldBe Some(phrase)
     }
 
     "Return None for a invalid index" in {
 
-      process.phraseOption(oneHundred) mustBe None
+      process.phraseOption(oneHundred) shouldBe None
     }
   }
 
@@ -67,12 +67,12 @@ class ProcessSpec extends BaseSpec with ProcessJson {
 
       val link: Link = Link(0, "http://www.bbc.co.uk/news", "BBC News", window = false)
 
-      process.linkOption(0) mustBe Some(link)
+      process.linkOption(0) shouldBe Some(link)
     }
 
     "Return None for an invalid index" in {
 
-      process.linkOption(ten) mustBe None
+      process.linkOption(ten) shouldBe None
     }
   }
 }

--- a/test/models/ocelot/stanzas/CalloutStanzaSpec.scala
+++ b/test/models/ocelot/stanzas/CalloutStanzaSpec.scala
@@ -16,11 +16,10 @@
 
 package models.ocelot.stanzas
 
+import base.UnitSpec
 import play.api.libs.json._
 
-import base.BaseSpec
-
-class CalloutStanzaSpec extends BaseSpec {
+class CalloutStanzaSpec extends UnitSpec {
 
   def getCalloutType[T](stanzaType: T): String = stanzaType.getClass.getSimpleName.dropRight(1)
 
@@ -74,7 +73,7 @@ class CalloutStanzaSpec extends BaseSpec {
     s"Reading valid JSON for a $jsonNoteType Callout" should {
       s"create a ${expectedStanza.noteType} Callout Stanza" in {
         val calloutStanza: CalloutStanza = json.as[CalloutStanza]
-        calloutStanza mustBe expectedStanza
+        calloutStanza shouldBe expectedStanza
       }
     }
   }

--- a/test/models/ocelot/stanzas/InstructionSpec.scala
+++ b/test/models/ocelot/stanzas/InstructionSpec.scala
@@ -16,10 +16,10 @@
 
 package models.ocelot.stanzas
 
-import org.scalatest.{MustMatchers, WordSpec}
+import base.UnitSpec
 import models.ocelot._
 
-class InstructionSpec extends WordSpec with MustMatchers {
+class InstructionSpec extends UnitSpec {
 
   trait Test {
     val text: Int = 10
@@ -46,14 +46,14 @@ class InstructionSpec extends WordSpec with MustMatchers {
 
     "contain a list of linked stanza ids drawn from placeholders within the text" in new Test {
       val instruction = Instruction(simpleInstruction, phrase0, None)
-      instruction.linkIds.length mustBe 0
+      instruction.linkIds.length shouldBe 0
     }
 
     "contain a list of linked stanza ids drawn from placeholders within the text and link" in new Test {
       val instruction = Instruction(linkInstruction, phrase0, Some(link))
-      instruction.linkIds.length mustBe 1
+      instruction.linkIds.length shouldBe 1
 
-      instruction.linkIds.contains(linkDest) mustBe true
+      instruction.linkIds.contains(linkDest) shouldBe true
     }
 
   }

--- a/test/models/ocelot/stanzas/InstructionStanzaSpec.scala
+++ b/test/models/ocelot/stanzas/InstructionStanzaSpec.scala
@@ -18,9 +18,9 @@ package models.ocelot.stanzas
 
 import play.api.libs.json._
 
-import base.BaseSpec
+import base.UnitSpec
 
-class InstructionStanzaSpec extends BaseSpec {
+class InstructionStanzaSpec extends UnitSpec {
 
   val stanzaType: String = "InstructionStanza"
   val text: Int = 10
@@ -59,7 +59,7 @@ class InstructionStanzaSpec extends BaseSpec {
 
       val validInstructionStanza: InstructionStanza = validInstructionStanzaJson.as[InstructionStanza]
 
-      validInstructionStanza mustBe expectedValidInstructionStanzaWithLink
+      validInstructionStanza shouldBe expectedValidInstructionStanzaWithLink
     }
 
     "Deserialising a valid Instruction Stanza without a link should create an instance of the class InstructionStanza" in {
@@ -68,7 +68,7 @@ class InstructionStanzaSpec extends BaseSpec {
 
       val validInstructionStanza: InstructionStanza = validInstructionStanzaJson.as[InstructionStanza]
 
-      validInstructionStanza mustBe expectedValidInstructionStanzaWithoutLink
+      validInstructionStanza shouldBe expectedValidInstructionStanzaWithoutLink
     }
 
     /** Test for missing properties in Json object representing instruction stanzas */

--- a/test/models/ocelot/stanzas/QuestionStanzaSpec.scala
+++ b/test/models/ocelot/stanzas/QuestionStanzaSpec.scala
@@ -16,11 +16,10 @@
 
 package models.ocelot.stanzas
 
+import base.UnitSpec
 import play.api.libs.json._
 
-import base.BaseSpec
-
-class QuestionStanzaSpec extends BaseSpec {
+class QuestionStanzaSpec extends UnitSpec {
 
   val zero: Int = 0
   val one: Int = 1
@@ -73,7 +72,7 @@ class QuestionStanzaSpec extends BaseSpec {
 
       val twoAnswersQuestionStanza: QuestionStanza = twoAnswersQuestionStanzaJson.as[QuestionStanza]
 
-      twoAnswersQuestionStanza mustBe expectedTwoQuestionsQuestionStanza
+      twoAnswersQuestionStanza shouldBe expectedTwoQuestionsQuestionStanza
     }
 
     "reading a valid QuestionStanza with three answers should create an instance of the class QuestionStanza" in {
@@ -82,7 +81,7 @@ class QuestionStanzaSpec extends BaseSpec {
 
       val threeAnswersQuestionStanza: QuestionStanza = threeAnswersQuestionStanzaJson.as[QuestionStanza]
 
-      threeAnswersQuestionStanza mustBe expectedThreeAnswersQuestionStanza
+      threeAnswersQuestionStanza shouldBe expectedThreeAnswersQuestionStanza
     }
 
     /** Test for missing properties in Json object */

--- a/test/models/ocelot/stanzas/StanzaSpec.scala
+++ b/test/models/ocelot/stanzas/StanzaSpec.scala
@@ -16,10 +16,10 @@
 
 package models.ocelot.stanzas
 
-import base.BaseSpec
+import base.UnitSpec
 import play.api.libs.json._
 
-class StanzaSpec extends BaseSpec {
+class StanzaSpec extends UnitSpec {
 
   val stanzaType = "ValueStanza"
   val valueType = "scalar"
@@ -59,7 +59,7 @@ class StanzaSpec extends BaseSpec {
 
       val stanza: Stanza = Json.parse("""{ "type": "EndStanza" }""").as[Stanza]
 
-      stanza mustBe EndStanza
+      stanza shouldBe EndStanza
     }
 
     "generate an error when an unknown stanza type is encountered" in {
@@ -76,7 +76,7 @@ class StanzaSpec extends BaseSpec {
 
       val stanza: Stanza = validValueStanzaJson.as[Stanza]
 
-      stanza mustBe ValueStanza(List(Value(Scalar, pageNameLabel, pageName), Value(Scalar, pageUrlLabel, pageUrl)), Seq(next), false)
+      stanza shouldBe ValueStanza(List(Value(Scalar, pageNameLabel, pageName), Value(Scalar, pageUrlLabel, pageUrl)), Seq(next), false)
     }
 
   }

--- a/test/models/ocelot/stanzas/ValueStanzaSpec.scala
+++ b/test/models/ocelot/stanzas/ValueStanzaSpec.scala
@@ -16,10 +16,10 @@
 
 package models.ocelot.stanzas
 
-import base.BaseSpec
+import base.UnitSpec
 import play.api.libs.json._
 
-class ValueStanzaSpec extends BaseSpec {
+class ValueStanzaSpec extends UnitSpec {
 
   val stanzaType = "ValueStanza"
   val valueType = "scalar"
@@ -82,12 +82,12 @@ class ValueStanzaSpec extends BaseSpec {
 
       val stanza: ValueStanza = validValueStanzaJson.as[ValueStanza]
 
-      stanza.stack mustBe false
-      stanza.next.length mustBe 1
-      stanza.next(0) mustBe next
-      stanza.values.length mustBe 2
-      stanza.values(0) mustBe Value(Scalar, pageNameLabel, pageName)
-      stanza.values(1) mustBe Value(Scalar, pageUrlLabel, pageUrl)
+      stanza.stack shouldBe false
+      stanza.next.length shouldBe 1
+      stanza.next(0) shouldBe next
+      stanza.values.length shouldBe 2
+      stanza.values(0) shouldBe Value(Scalar, pageNameLabel, pageName)
+      stanza.values(1) shouldBe Value(Scalar, pageUrlLabel, pageUrl)
     }
 
     "fail to parse if an unkown value type is found" in {
@@ -98,7 +98,7 @@ class ValueStanzaSpec extends BaseSpec {
     }
 
     "contain at least one Value object" in {
-      validValueStanzaJson.as[ValueStanza].values.length must be > 0
+      validValueStanzaJson.as[ValueStanza].values.length should be > 0
     }
 
     missingJsObjectAttrTests[ValueStanza](validValueStanzaJson, List("type"))

--- a/test/repositories/formatters/ScratchProcessFormatterSpec.scala
+++ b/test/repositories/formatters/ScratchProcessFormatterSpec.scala
@@ -18,11 +18,11 @@ package repositories.formatters
 
 import java.util.UUID
 
-import base.BaseSpec
+import base.UnitSpec
 import models.ScratchProcess
 import play.api.libs.json.{JsSuccess, Json}
 
-class ScratchProcessFormatterSpec extends BaseSpec {
+class ScratchProcessFormatterSpec extends UnitSpec {
 
   private val id = "3475e5c5-343d-4214-9efc-58270867214c"
   private val process = ScratchProcess(UUID.fromString(id), Json.obj())
@@ -49,7 +49,7 @@ class ScratchProcessFormatterSpec extends BaseSpec {
   "Serialising a ScratchProcess to JSON" should {
     "result in the correct JSON" in {
       val result = Json.toJson(process)(ScratchProcessFormatter.mongoFormat)
-      result mustBe json
+      result shouldBe json
     }
   }
 }


### PR DESCRIPTION
- Added error handling using the `Either[Error, T]` pattern
- Standardised unit testing with new `UnitSpec`
  - Settled on use of `Matchers` trait so matching done using `shouldBe` rather than `mustBe`
- Removed redundant code
- Refactored all test to use new `UnitSpec`
- Added test cases introduced by adding error handling
- Reimplemented `ScratchRepository` to use the `findById` and `insert` functions in `ReactiveRepository` rather than using the `collection` val
- Renamed functions to not include implementation details e.g. `getByUuid` to `getById`
- Updated `README`
- Updated dependencies