### PR TITLE
EG-420 approval list endpoint (also includes EG-421 - include status in save)

### DIFF
--- a/app/controllers/ApprovalController.scala
+++ b/app/controllers/ApprovalController.scala
@@ -18,15 +18,20 @@ package controllers
 
 import javax.inject.{Inject, Singleton}
 import models.errors.{BadRequestError, Errors, InternalServiceError, NotFoundError}
-import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.ApprovalService
 import uk.gov.hmrc.play.bootstrap.controller.BackendController
-
 import scala.concurrent.ExecutionContext.Implicits.global
+
+import models.{ApprovalProcess, ApprovalProcessMeta}
+import repositories.formatters.{ApprovalProcessFormatter, ApprovalProcessMetaFormatter}
 
 @Singleton
 class ApprovalController @Inject() (approvalService: ApprovalService, cc: ControllerComponents) extends BackendController(cc) {
+
+  implicit val apFormat: Format[ApprovalProcess] = ApprovalProcessFormatter.mongoFormat
+  implicit val apmFormat: Format[ApprovalProcessMeta] = ApprovalProcessMetaFormatter.mongoFormat
 
   def save: Action[JsValue] = Action.async(parse.json) { implicit request =>
     val process = request.body.as[JsObject]

--- a/app/controllers/ApprovalController.scala
+++ b/app/controllers/ApprovalController.scala
@@ -24,14 +24,8 @@ import services.ApprovalService
 import uk.gov.hmrc.play.bootstrap.controller.BackendController
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import models.{ApprovalProcess, ApprovalProcessMeta}
-import repositories.formatters.{ApprovalProcessFormatter, ApprovalProcessMetaFormatter}
-
 @Singleton
 class ApprovalController @Inject() (approvalService: ApprovalService, cc: ControllerComponents) extends BackendController(cc) {
-
-  implicit val apFormat: Format[ApprovalProcess] = ApprovalProcessFormatter.mongoFormat
-  implicit val apmFormat: Format[ApprovalProcessMeta] = ApprovalProcessMetaFormatter.mongoFormat
 
   def save: Action[JsValue] = Action.async(parse.json) { implicit request =>
     val process = request.body.as[JsObject]
@@ -45,7 +39,7 @@ class ApprovalController @Inject() (approvalService: ApprovalService, cc: Contro
 
   def get(id: String): Action[AnyContent] = Action.async { _ =>
     approvalService.getById(id).map {
-      case Right(approvalProcess) => Ok(Json.toJson(approvalProcess))
+      case Right(approvalProcess) => Ok(approvalProcess)
       case Left(Errors(NotFoundError :: Nil)) => NotFound(Json.toJson(NotFoundError))
       case Left(Errors(BadRequestError :: Nil)) => BadRequest(Json.toJson(BadRequestError))
       case Left(_) => InternalServerError(Json.toJson(InternalServiceError))

--- a/app/controllers/ApprovalController.scala
+++ b/app/controllers/ApprovalController.scala
@@ -52,10 +52,10 @@ class ApprovalController @Inject() (approvalService: ApprovalService, cc: Contro
     }
   }
 
-  def listForAdminHomePage: Action[AnyContent] = Action.async { _ =>
-    approvalService.listForHomePage().map {
+  def approvalSummaryList: Action[AnyContent] = Action.async { _ =>
+    approvalService.approvalSummaryList().map {
       case Right(list) =>
-        Ok(Json.toJson(list))
+        Ok(list)
       case _ => InternalServerError(Json.toJson(InternalServiceError))
     }
   }

--- a/app/controllers/ApprovalController.scala
+++ b/app/controllers/ApprovalController.scala
@@ -40,10 +40,19 @@ class ApprovalController @Inject() (approvalService: ApprovalService, cc: Contro
 
   def get(id: String): Action[AnyContent] = Action.async { _ =>
     approvalService.getById(id).map {
-      case Right(process) => Ok(process)
+      case Right(approvalProcess) => Ok(Json.toJson(approvalProcess))
       case Left(Errors(NotFoundError :: Nil)) => NotFound(Json.toJson(NotFoundError))
       case Left(Errors(BadRequestError :: Nil)) => BadRequest(Json.toJson(BadRequestError))
       case Left(_) => InternalServerError(Json.toJson(InternalServiceError))
     }
   }
+
+  def listForAdminHomePage: Action[AnyContent] = Action.async { _ =>
+    approvalService.listForHomePage().map {
+      case Right(list) =>
+        Ok(Json.toJson(list))
+      case _ => InternalServerError(Json.toJson(InternalServiceError))
+    }
+  }
+
 }

--- a/app/models/ApprovalProcess.scala
+++ b/app/models/ApprovalProcess.scala
@@ -16,6 +16,25 @@
 
 package models
 
-import play.api.libs.json.JsObject
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
 
-case class ApprovalProcess(id: String, process: JsObject)
+case class ApprovalProcess(id: String, meta: ApprovalProcessMeta, process: JsObject)
+
+object ApprovalProcess {
+
+  implicit val reads: Reads[ApprovalProcess] = (
+    (__ \ "id").read[String] and
+      (__ \ "meta").read[ApprovalProcessMeta] and
+      (__ \ "process").read[JsObject]
+    )(ApprovalProcess.apply _)
+
+  implicit val writes: Writes[ApprovalProcess] = (
+    (JsPath \ "id").write[String] and
+      (JsPath \ "meta").write[ApprovalProcessMeta] and
+      (JsPath \ "process").write[JsObject]
+    )(unlift(ApprovalProcess.unapply))
+
+//  val mongoFormat: OFormat[ApprovalProcess] = OFormat(reads, writes)
+
+}

--- a/app/models/ApprovalProcess.scala
+++ b/app/models/ApprovalProcess.scala
@@ -16,7 +16,6 @@
 
 package models
 
-import play.api.libs.functional.syntax._
-import play.api.libs.json._
+import play.api.libs.json.JsObject
 
 case class ApprovalProcess(id: String, meta: ApprovalProcessMeta, process: JsObject)

--- a/app/models/ApprovalProcess.scala
+++ b/app/models/ApprovalProcess.scala
@@ -20,21 +20,3 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 case class ApprovalProcess(id: String, meta: ApprovalProcessMeta, process: JsObject)
-
-object ApprovalProcess {
-
-  implicit val reads: Reads[ApprovalProcess] = (
-    (__ \ "id").read[String] and
-      (__ \ "meta").read[ApprovalProcessMeta] and
-      (__ \ "process").read[JsObject]
-    )(ApprovalProcess.apply _)
-
-  implicit val writes: Writes[ApprovalProcess] = (
-    (JsPath \ "id").write[String] and
-      (JsPath \ "meta").write[ApprovalProcessMeta] and
-      (JsPath \ "process").write[JsObject]
-    )(unlift(ApprovalProcess.unapply))
-
-//  val mongoFormat: OFormat[ApprovalProcess] = OFormat(reads, writes)
-
-}

--- a/app/models/ApprovalProcessMeta.scala
+++ b/app/models/ApprovalProcessMeta.scala
@@ -16,9 +16,6 @@
 
 package models
 
-import org.joda.time.DateTime
-import play.api.libs.functional.syntax._
-import play.api.libs.json._
-import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+import org.joda.time.LocalDateTime
 
-case class ApprovalProcessMeta(id: String, title: String, status: String, dateSubmitted: DateTime)
+case class ApprovalProcessMeta(id: String, title: String, status: String, dateSubmitted: LocalDateTime)

--- a/app/models/ApprovalProcessMeta.scala
+++ b/app/models/ApprovalProcessMeta.scala
@@ -22,21 +22,3 @@ import play.api.libs.json._
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
 case class ApprovalProcessMeta(id: String, title: String, status: String, dateSubmitted: DateTime)
-
-object ApprovalProcessMeta {
-  implicit val dateFormat: Format[DateTime] = ReactiveMongoFormats.dateTimeFormats
-
-  implicit val reads: Reads[ApprovalProcessMeta] = (
-    (__ \ "id").read[String] and
-      (__ \ "title").read[String] and
-      (__ \ "status").read[String] and
-      (__ \ "dateSubmitted").read(ReactiveMongoFormats.dateTimeRead)
-    )(ApprovalProcessMeta.apply _)
-
-  implicit val writes: Writes[ApprovalProcessMeta] = (
-    (JsPath \ "id").write[String] and
-      (JsPath \ "title").write[String] and
-      (JsPath \ "status").write[String] and
-      (JsPath \ "dateSubmitted").write(ReactiveMongoFormats.dateTimeWrite)
-    )(unlift(ApprovalProcessMeta.unapply))
-}

--- a/app/models/ApprovalProcessMeta.scala
+++ b/app/models/ApprovalProcessMeta.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import org.joda.time.DateTime
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+
+case class ApprovalProcessMeta(id: String, title: String, status: String, dateSubmitted: DateTime)
+
+object ApprovalProcessMeta {
+  implicit val dateFormat: Format[DateTime] = ReactiveMongoFormats.dateTimeFormats
+
+  implicit val reads: Reads[ApprovalProcessMeta] = (
+    (__ \ "id").read[String] and
+      (__ \ "title").read[String] and
+      (__ \ "status").read[String] and
+      (__ \ "dateSubmitted").read(ReactiveMongoFormats.dateTimeRead)
+    )(ApprovalProcessMeta.apply _)
+
+  implicit val writes: Writes[ApprovalProcessMeta] = (
+    (JsPath \ "id").write[String] and
+      (JsPath \ "title").write[String] and
+      (JsPath \ "status").write[String] and
+      (JsPath \ "dateSubmitted").write(ReactiveMongoFormats.dateTimeWrite)
+    )(unlift(ApprovalProcessMeta.unapply))
+}

--- a/app/models/ApprovalProcessSummary.scala
+++ b/app/models/ApprovalProcessSummary.scala
@@ -16,6 +16,11 @@
 
 package models
 
+import play.api.libs.json.{Json, OFormat}
 import java.time.LocalDate
 
-case class ApprovalProcessMeta(id: String, title: String, status: String, dateSubmitted: LocalDate)
+case class ApprovalProcessSummary(id: String, title: String, lastUpdated: LocalDate, status: String)
+
+object ApprovalProcessSummary {
+  implicit val formats: OFormat[ApprovalProcessSummary] = Json.format[ApprovalProcessSummary]
+}

--- a/app/models/MongoDateTimeFormats.scala
+++ b/app/models/MongoDateTimeFormats.scala
@@ -16,6 +16,23 @@
 
 package models
 
-import java.time.LocalDate
+import java.time.{Instant, LocalDate, ZoneOffset}
 
-case class ApprovalProcessMeta(id: String, title: String, status: String, dateSubmitted: LocalDate)
+import play.api.libs.json._
+
+trait MongoDateTimeFormats {
+
+  implicit val localDateRead: Reads[LocalDate] =
+    (__ \ "$date").read[Long].map { millis =>
+      Instant.ofEpochMilli(millis).atZone(ZoneOffset.UTC).toLocalDate
+    }
+
+  implicit val localDateWrite: Writes[LocalDate] = (localDate: LocalDate) =>
+    Json.obj(
+      "$date" -> localDate.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
+    )
+
+  implicit val localDateFormats: Format[LocalDate] = Format(localDateRead, localDateWrite)
+
+}
+object MongoDateTimeFormats extends MongoDateTimeFormats

--- a/app/repositories/ApprovalRepository.scala
+++ b/app/repositories/ApprovalRepository.scala
@@ -19,8 +19,11 @@ package repositories
 import javax.inject.{Inject, Singleton}
 import models.errors.{DatabaseError, Errors, NotFoundError}
 import models.{ApprovalProcess, RequestOutcome}
-import play.api.libs.json.{Format, JsObject, Json}
+import play.api.libs.json.{Format, Json}
 import play.modules.reactivemongo.ReactiveMongoComponent
+import reactivemongo.api.Cursor.FailOnError
+import reactivemongo.api.ReadPreference
+import reactivemongo.play.json.ImplicitBSONHandlers._
 import repositories.formatters.ApprovalProcessFormatter
 import uk.gov.hmrc.mongo.ReactiveRepository
 
@@ -28,12 +31,13 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 trait ApprovalRepository {
-  def update(id: String, process: JsObject): Future[RequestOutcome[String]]
-  def getById(id: String): Future[RequestOutcome[JsObject]]
+  def update(id: String, process: ApprovalProcess): Future[RequestOutcome[String]]
+  def getById(id: String): Future[RequestOutcome[ApprovalProcess]]
+  def listForHomePage(): Future[RequestOutcome[List[ApprovalProcess]]]
 }
 
 @Singleton
-class ApprovalRepositoryImpl @Inject() (mongoComponent: ReactiveMongoComponent)
+class ApprovalRepositoryImpl @Inject() (implicit mongoComponent: ReactiveMongoComponent)
     extends ReactiveRepository[ApprovalProcess, String](
       collectionName = "approvalProcesses",
       mongo = mongoComponent.mongoConnector.db,
@@ -42,16 +46,14 @@ class ApprovalRepositoryImpl @Inject() (mongoComponent: ReactiveMongoComponent)
     )
     with ApprovalRepository {
 
-  def update(id: String, process: JsObject): Future[RequestOutcome[String]] = {
+  def update(id: String, process: ApprovalProcess): Future[RequestOutcome[String]] = {
 
     logger.info(s"Saving process $id to collection $collectionName")
-    val document: ApprovalProcess = ApprovalProcess(id, process)
-
     val selector = Json.obj("_id" -> id)
-    val entity = Json.toJsObject(document)(ApprovalProcessFormatter.mongoFormat)
+    val jsonProcess = Json.toJsObject(process)(ApprovalProcessFormatter.mongoFormat)
 
     this
-      .findAndUpdate(selector, entity, upsert = true)
+      .findAndUpdate(selector, jsonProcess, upsert = true)
       .map { _ =>
         Right(id)
       }
@@ -64,11 +66,11 @@ class ApprovalRepositoryImpl @Inject() (mongoComponent: ReactiveMongoComponent)
     //$COVERAGE-ON$
   }
 
-  def getById(id: String): Future[RequestOutcome[JsObject]] = {
+  def getById(id: String): Future[RequestOutcome[ApprovalProcess]] = {
 
     findById(id)
       .map {
-        case Some(approvalProcess) => Right(approvalProcess.process)
+        case Some(approvalProcess) => Right(approvalProcess)
         case None => Left(Errors(NotFoundError))
       }
       //$COVERAGE-OFF$
@@ -78,6 +80,25 @@ class ApprovalRepositoryImpl @Inject() (mongoComponent: ReactiveMongoComponent)
           Left(Errors(DatabaseError))
       }
     //$COVERAGE-ON$
+  }
+
+  def listForHomePage(): Future[RequestOutcome[List[ApprovalProcess]]] = {
+    val selector = Json.obj()
+    val projection = Some(Json.obj("meta" -> 1, "process.mata.id" -> 1))
+
+      collection
+        .find(
+          selector,
+          projection
+        )
+        .cursor[ApprovalProcess](ReadPreference.primaryPreferred)
+        .collect(maxDocs = -1, FailOnError[List[ApprovalProcess]]())
+        .map(list => Right(list))
+        .recover {
+          case error =>
+            logger.error(s"Attempt to retrieve list of processes from collection $collectionName failed with error : ${error.getMessage}")
+            Left(Errors(DatabaseError))
+        }
   }
 
 }

--- a/app/repositories/ApprovalRepository.scala
+++ b/app/repositories/ApprovalRepository.scala
@@ -19,7 +19,7 @@ package repositories
 import javax.inject.{Inject, Singleton}
 import models.errors.{DatabaseError, Errors, NotFoundError}
 import models.{ApprovalProcess, ApprovalProcessSummary, RequestOutcome}
-import play.api.libs.json.{Format, Json}
+import play.api.libs.json.{Format, JsObject, Json}
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.Cursor.FailOnError
 import reactivemongo.api.ReadPreference
@@ -32,7 +32,7 @@ import scala.concurrent.Future
 
 trait ApprovalRepository {
   def update(id: String, process: ApprovalProcess): Future[RequestOutcome[String]]
-  def getById(id: String): Future[RequestOutcome[ApprovalProcess]]
+  def getById(id: String): Future[RequestOutcome[JsObject]]
   def approvalSummaryList(): Future[RequestOutcome[List[ApprovalProcessSummary]]]
 }
 
@@ -66,11 +66,11 @@ class ApprovalRepositoryImpl @Inject() (implicit mongoComponent: ReactiveMongoCo
     //$COVERAGE-ON$
   }
 
-  def getById(id: String): Future[RequestOutcome[ApprovalProcess]] = {
+  def getById(id: String): Future[RequestOutcome[JsObject]] = {
 
     findById(id)
       .map {
-        case Some(approvalProcess) => Right(approvalProcess)
+        case Some(approvalProcess) => Right(approvalProcess.process)
         case None => Left(Errors(NotFoundError))
       }
       //$COVERAGE-OFF$

--- a/app/repositories/ApprovalRepository.scala
+++ b/app/repositories/ApprovalRepository.scala
@@ -84,21 +84,23 @@ class ApprovalRepositoryImpl @Inject() (implicit mongoComponent: ReactiveMongoCo
 
   def listForHomePage(): Future[RequestOutcome[List[ApprovalProcess]]] = {
     val selector = Json.obj()
-    val projection = Some(Json.obj("meta" -> 1, "process.mata.id" -> 1))
+    val projection = Some(Json.obj("meta" -> 1, "process.meta.id" -> 1))
 
-      collection
-        .find(
-          selector,
-          projection
-        )
-        .cursor[ApprovalProcess](ReadPreference.primaryPreferred)
-        .collect(maxDocs = -1, FailOnError[List[ApprovalProcess]]())
-        .map(list => Right(list))
-        .recover {
-          case error =>
-            logger.error(s"Attempt to retrieve list of processes from collection $collectionName failed with error : ${error.getMessage}")
-            Left(Errors(DatabaseError))
-        }
+    collection
+      .find(
+        selector,
+        projection
+      )
+      .cursor[ApprovalProcess](ReadPreference.primaryPreferred)
+      .collect(maxDocs = -1, FailOnError[List[ApprovalProcess]]())
+      .map(list => Right(list))
+      //$COVERAGE-OFF$
+      .recover {
+        case error =>
+          logger.error(s"Attempt to retrieve list of processes from collection $collectionName failed with error : ${error.getMessage}")
+          Left(Errors(DatabaseError))
+      }
+    //$COVERAGE-ON$
   }
 
 }

--- a/app/repositories/ApprovalRepository.scala
+++ b/app/repositories/ApprovalRepository.scala
@@ -33,7 +33,7 @@ import scala.concurrent.Future
 trait ApprovalRepository {
   def update(id: String, process: ApprovalProcess): Future[RequestOutcome[String]]
   def getById(id: String): Future[RequestOutcome[ApprovalProcess]]
-  def listForHomePage(): Future[RequestOutcome[List[ApprovalProcessSummary]]]
+  def approvalSummaryList(): Future[RequestOutcome[List[ApprovalProcessSummary]]]
 }
 
 @Singleton
@@ -82,7 +82,7 @@ class ApprovalRepositoryImpl @Inject() (implicit mongoComponent: ReactiveMongoCo
     //$COVERAGE-ON$
   }
 
-  def listForHomePage(): Future[RequestOutcome[List[ApprovalProcessSummary]]] = {
+  def approvalSummaryList(): Future[RequestOutcome[List[ApprovalProcessSummary]]] = {
     val selector = Json.obj("meta" -> Json.obj("$exists" -> true))
     val projection = Some(Json.obj("meta" -> 1, "process.meta.id" -> 1))
 

--- a/app/repositories/ApprovalRepository.scala
+++ b/app/repositories/ApprovalRepository.scala
@@ -83,7 +83,7 @@ class ApprovalRepositoryImpl @Inject() (implicit mongoComponent: ReactiveMongoCo
   }
 
   def listForHomePage(): Future[RequestOutcome[List[ApprovalProcessSummary]]] = {
-    val selector = Json.obj()
+    val selector = Json.obj("meta" -> Json.obj("$exists" -> true))
     val projection = Some(Json.obj("meta" -> 1, "process.meta.id" -> 1))
 
     collection

--- a/app/repositories/formatters/ApprovalProcessFormatter.scala
+++ b/app/repositories/formatters/ApprovalProcessFormatter.scala
@@ -37,5 +37,5 @@ object ApprovalProcessFormatter {
       "process" -> Json.toJson(approvalProcess.process)
     )
 
-  val mongoFormat: OFormat[ApprovalProcess] = OFormat(read, write)
+  implicit val mongoFormat: OFormat[ApprovalProcess] = OFormat(read, write)
 }

--- a/app/repositories/formatters/ApprovalProcessFormatter.scala
+++ b/app/repositories/formatters/ApprovalProcessFormatter.scala
@@ -33,7 +33,7 @@ object ApprovalProcessFormatter {
   val write: ApprovalProcess => JsObject = approvalProcess =>
     Json.obj(
       "_id" -> approvalProcess.id,
-      "meta" -> Json.toJsFieldJsValueWrapper(approvalProcess.meta),
+      "meta" -> Json.toJson(approvalProcess.meta),
       "process" -> Json.toJson(approvalProcess.process)
     )
 

--- a/app/repositories/formatters/ApprovalProcessFormatter.scala
+++ b/app/repositories/formatters/ApprovalProcessFormatter.scala
@@ -21,6 +21,8 @@ import play.api.libs.json._
 
 object ApprovalProcessFormatter {
 
+  implicit val metaFormatter: Format[ApprovalProcessMeta] = ApprovalProcessMetaFormatter.mongoFormat
+
   val read: JsValue => JsResult[ApprovalProcess] = json =>
     for {
       id <- (json \ "_id").validate[String]

--- a/app/repositories/formatters/ApprovalProcessFormatter.scala
+++ b/app/repositories/formatters/ApprovalProcessFormatter.scala
@@ -25,10 +25,10 @@ object ApprovalProcessFormatter {
 
   val read: JsValue => JsResult[ApprovalProcess] = json =>
     for {
-      id <- (json \ "_id").validate[String]
+      id <- (json \ "_id").validateOpt[String]
       meta <- (json \ "meta").validate[ApprovalProcessMeta]
       process <- (json \ "process").validate[JsObject]
-    } yield ApprovalProcess(id, meta, process)
+    } yield ApprovalProcess(id.getOrElse(meta.id), meta, process)
 
   val write: ApprovalProcess => JsObject = approvalProcess =>
     Json.obj(

--- a/app/repositories/formatters/ApprovalProcessFormatter.scala
+++ b/app/repositories/formatters/ApprovalProcessFormatter.scala
@@ -16,7 +16,7 @@
 
 package repositories.formatters
 
-import models.ApprovalProcess
+import models.{ApprovalProcess, ApprovalProcessMeta}
 import play.api.libs.json._
 
 object ApprovalProcessFormatter {
@@ -24,13 +24,15 @@ object ApprovalProcessFormatter {
   val read: JsValue => JsResult[ApprovalProcess] = json =>
     for {
       id <- (json \ "_id").validate[String]
+      meta <- (json \ "meta").validate[ApprovalProcessMeta]
       process <- (json \ "process").validate[JsObject]
-    } yield ApprovalProcess(id, process)
+    } yield ApprovalProcess(id, meta, process)
 
   val write: ApprovalProcess => JsObject = approvalProcess =>
     Json.obj(
       "_id" -> approvalProcess.id,
-      "process" -> approvalProcess.process
+      "meta" -> Json.toJsFieldJsValueWrapper(approvalProcess.meta),
+      "process" -> Json.toJson(approvalProcess.process)
     )
 
   val mongoFormat: OFormat[ApprovalProcess] = OFormat(read, write)

--- a/app/repositories/formatters/ApprovalProcessMetaFormatter.scala
+++ b/app/repositories/formatters/ApprovalProcessMetaFormatter.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories.formatters
+
+import models.ApprovalProcessMeta
+import org.joda.time.DateTime
+import play.api.libs.json._
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+
+object ApprovalProcessMetaFormatter {
+
+  implicit val dateFormat: Format[DateTime] = ReactiveMongoFormats.dateTimeFormats
+
+  val read: JsValue => JsResult[ApprovalProcessMeta] = json =>
+    for {
+      id <- (json \ "id").validate[String]
+      status <- (json \ "status").validate[String]
+      title <- (json \ "title").validate[String]
+      dateSubmitted <- (json \ "dateSubmitted").validate[DateTime](dateFormat)
+    } yield ApprovalProcessMeta(id, title, status, dateSubmitted)
+
+  val write: ApprovalProcessMeta => JsObject = meta =>
+    Json.obj(
+      "id" -> meta.id,
+      "status" -> meta.status,
+      "title" -> meta.title,
+      "dateSubmitted" -> meta.dateSubmitted
+    )
+
+  val mongoFormat: OFormat[ApprovalProcessMeta] = OFormat(read, write)
+}

--- a/app/repositories/formatters/ApprovalProcessMetaFormatter.scala
+++ b/app/repositories/formatters/ApprovalProcessMetaFormatter.scala
@@ -16,21 +16,21 @@
 
 package repositories.formatters
 
-import models.ApprovalProcessMeta
-import org.joda.time.LocalDateTime
+import java.time.LocalDate
+
+import models.{ApprovalProcessMeta, MongoDateTimeFormats}
 import play.api.libs.json._
-import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
 object ApprovalProcessMetaFormatter {
 
-  implicit val dateFormat: Format[LocalDateTime] = ReactiveMongoFormats.localDateTimeFormats
+  implicit val dateFormat: Format[LocalDate] = MongoDateTimeFormats.localDateFormats
 
   val read: JsValue => JsResult[ApprovalProcessMeta] = json =>
     for {
       id <- (json \ "id").validate[String]
       status <- (json \ "status").validate[String]
       title <- (json \ "title").validate[String]
-      dateSubmitted <- (json \ "dateSubmitted").validate[LocalDateTime](dateFormat)
+      dateSubmitted <- (json \ "dateSubmitted").validate[LocalDate](dateFormat)
     } yield ApprovalProcessMeta(id, title, status, dateSubmitted)
 
   val write: ApprovalProcessMeta => JsObject = meta =>

--- a/app/repositories/formatters/ApprovalProcessMetaFormatter.scala
+++ b/app/repositories/formatters/ApprovalProcessMetaFormatter.scala
@@ -17,20 +17,20 @@
 package repositories.formatters
 
 import models.ApprovalProcessMeta
-import org.joda.time.DateTime
+import org.joda.time.LocalDateTime
 import play.api.libs.json._
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
 object ApprovalProcessMetaFormatter {
 
-  implicit val dateFormat: Format[DateTime] = ReactiveMongoFormats.dateTimeFormats
+  implicit val dateFormat: Format[LocalDateTime] = ReactiveMongoFormats.localDateTimeFormats
 
   val read: JsValue => JsResult[ApprovalProcessMeta] = json =>
     for {
       id <- (json \ "id").validate[String]
       status <- (json \ "status").validate[String]
       title <- (json \ "title").validate[String]
-      dateSubmitted <- (json \ "dateSubmitted").validate[DateTime](dateFormat)
+      dateSubmitted <- (json \ "dateSubmitted").validate[LocalDateTime](dateFormat)
     } yield ApprovalProcessMeta(id, title, status, dateSubmitted)
 
   val write: ApprovalProcessMeta => JsObject = meta =>

--- a/app/repositories/formatters/ApprovalProcessMetaFormatter.scala
+++ b/app/repositories/formatters/ApprovalProcessMetaFormatter.scala
@@ -30,7 +30,7 @@ object ApprovalProcessMetaFormatter {
       id <- (json \ "id").validate[String]
       status <- (json \ "status").validate[String]
       title <- (json \ "title").validate[String]
-      dateSubmitted <- (json \ "dateSubmitted").validate[LocalDate](dateFormat)
+      dateSubmitted <- (json \ "dateSubmitted").validate[LocalDate]
     } yield ApprovalProcessMeta(id, title, status, dateSubmitted)
 
   val write: ApprovalProcessMeta => JsObject = meta =>

--- a/app/services/ApprovalService.scala
+++ b/app/services/ApprovalService.scala
@@ -18,7 +18,7 @@ package services
 
 import javax.inject.{Inject, Singleton}
 import models.errors.{BadRequestError, Errors, InternalServiceError, NotFoundError}
-import models.{ApprovalProcess, ApprovalProcessSummary, RequestOutcome}
+import models.{ApprovalProcess, RequestOutcome}
 import play.api.Logger
 import play.api.libs.json._
 import repositories.ApprovalRepository
@@ -61,10 +61,10 @@ class ApprovalService @Inject() (repository: ApprovalRepository) {
     }
   }
 
-  def listForHomePage(): Future[RequestOutcome[List[ApprovalProcessSummary]]] = {
-    repository.listForHomePage().map {
+  def approvalSummaryList(): Future[RequestOutcome[JsArray]] = {
+    repository.approvalSummaryList().map {
       case Left(_) => Left(Errors(InternalServiceError))
-      case Right(success) => Right(success)
+      case Right(success) => Right(Json.toJson(success).as[JsArray])
     }
   }
 }

--- a/app/services/ApprovalService.scala
+++ b/app/services/ApprovalService.scala
@@ -17,9 +17,8 @@
 package services
 
 import javax.inject.{Inject, Singleton}
-import models.RequestOutcome
 import models.errors.{BadRequestError, Errors, InternalServiceError, NotFoundError}
-import models.ocelot.Process
+import models.{ApprovalProcess, ApprovalProcessMeta, RequestOutcome}
 import play.api.Logger
 import play.api.libs.json.{JsError, JsObject, JsSuccess}
 import repositories.ApprovalRepository
@@ -32,15 +31,18 @@ class ApprovalService @Inject() (repository: ApprovalRepository) {
 
   val logger: Logger = Logger(this.getClass)
 
-  def save(process: JsObject): Future[RequestOutcome[String]] = {
+  def save(approvalProcess: JsObject): Future[RequestOutcome[String]] = {
 
-    def saveProcess(id: String): Future[RequestOutcome[String]] = repository.update(id, process) map {
-      case Left(_) => Left(Errors(InternalServiceError))
-      case result => result
+    def saveProcess(process: ApprovalProcess): Future[RequestOutcome[String]] = {
+      repository.update(process.meta.id, process) map {
+        case Left(_) => Left(Errors(InternalServiceError))
+        case result => result
+      }
     }
 
-    process.validate[Process] match {
-      case JsSuccess(process, _) => saveProcess(process.meta.id)
+    approvalProcess.validate[ApprovalProcess] match {
+      case JsSuccess(process, _) =>
+        saveProcess(process)
       case JsError(errors) =>
         logger.error(s"Parsing process failed with the following error(s): $errors")
         Future { Left(Errors(BadRequestError)) }
@@ -48,12 +50,25 @@ class ApprovalService @Inject() (repository: ApprovalRepository) {
 
   }
 
-  def getById(id: String): Future[RequestOutcome[JsObject]] = {
+  def getById(id: String): Future[RequestOutcome[ApprovalProcess]] = {
 
     repository.getById(id) map {
       case error @ Left(Errors(NotFoundError :: Nil)) => error
       case Left(_) => Left(Errors(InternalServiceError))
       case result => result
+    }
+  }
+
+  def listForHomePage(): Future[RequestOutcome[List[ApprovalProcessMeta]]] = {
+    repository.listForHomePage().map {
+      case Left(_) => Left(Errors(InternalServiceError))
+      case Right(success) =>
+        Right(success
+          .map { ap => ApprovalProcessMeta(ap.meta.id, ap.meta.title, ap.meta.status, ap.meta.dateSubmitted)}
+        )
+    }.recover {
+      case e: Exception =>
+        Left(Errors(InternalServiceError))
     }
   }
 

--- a/app/services/ApprovalService.scala
+++ b/app/services/ApprovalService.scala
@@ -71,9 +71,6 @@ class ApprovalService @Inject() (repository: ApprovalRepository) {
         Right(success
           .map { ap => ApprovalProcessMeta(ap.meta.id, ap.meta.title, ap.meta.status, ap.meta.dateSubmitted)}
         )
-    }.recover {
-      case e: Exception =>
-        Left(Errors(InternalServiceError))
     }
   }
 

--- a/app/services/ApprovalService.scala
+++ b/app/services/ApprovalService.scala
@@ -20,8 +20,10 @@ import javax.inject.{Inject, Singleton}
 import models.errors.{BadRequestError, Errors, InternalServiceError, NotFoundError}
 import models.{ApprovalProcess, ApprovalProcessMeta, RequestOutcome}
 import play.api.Logger
-import play.api.libs.json.{JsError, JsObject, JsSuccess}
+import play.api.libs.json._
 import repositories.ApprovalRepository
+import models.{ApprovalProcess, ApprovalProcessMeta}
+import repositories.formatters.{ApprovalProcessFormatter, ApprovalProcessMetaFormatter}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -30,6 +32,9 @@ import scala.concurrent.Future
 class ApprovalService @Inject() (repository: ApprovalRepository) {
 
   val logger: Logger = Logger(this.getClass)
+  implicit val apFormat: Format[ApprovalProcess] = ApprovalProcessFormatter.mongoFormat
+  implicit val apmFormat: Format[ApprovalProcessMeta] = ApprovalProcessMetaFormatter.mongoFormat
+
 
   def save(approvalProcess: JsObject): Future[RequestOutcome[String]] = {
 

--- a/app/services/ApprovalService.scala
+++ b/app/services/ApprovalService.scala
@@ -64,14 +64,7 @@ class ApprovalService @Inject() (repository: ApprovalRepository) {
   def listForHomePage(): Future[RequestOutcome[List[ApprovalProcessSummary]]] = {
     repository.listForHomePage().map {
       case Left(_) => Left(Errors(InternalServiceError))
-      case Right(success) =>
-        Right(
-          success
-            .map { ap =>
-              ApprovalProcessSummary(ap.meta.id, ap.meta.title, ap.meta.dateSubmitted, ap.meta.status)
-            }
-        )
+      case Right(success) => Right(success)
     }
   }
-
 }

--- a/app/services/ApprovalService.scala
+++ b/app/services/ApprovalService.scala
@@ -22,7 +22,7 @@ import models.{ApprovalProcess, RequestOutcome}
 import play.api.Logger
 import play.api.libs.json._
 import repositories.ApprovalRepository
-import repositories.formatters.ApprovalProcessFormatter
+import repositories.formatters.ApprovalProcessFormatter.mongoFormat
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -31,7 +31,6 @@ import scala.concurrent.Future
 class ApprovalService @Inject() (repository: ApprovalRepository) {
 
   val logger: Logger = Logger(this.getClass)
-  implicit val apFormat: Format[ApprovalProcess] = ApprovalProcessFormatter.mongoFormat
 
   def save(approvalProcess: JsObject): Future[RequestOutcome[String]] = {
 
@@ -52,7 +51,7 @@ class ApprovalService @Inject() (repository: ApprovalRepository) {
 
   }
 
-  def getById(id: String): Future[RequestOutcome[ApprovalProcess]] = {
+  def getById(id: String): Future[RequestOutcome[JsObject]] = {
 
     repository.getById(id) map {
       case error @ Left(Errors(NotFoundError :: Nil)) => error

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -5,5 +5,7 @@ POST        /scratch              controllers.ScratchController.save
 
 GET         /published/:id        controllers.PublishedController.get(id)
 
+GET         /approval/list        controllers.ApprovalController.listForAdminHomePage
 GET         /approval/:id         controllers.ApprovalController.get(id)
 POST        /approval             controllers.ApprovalController.save
+

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -5,7 +5,7 @@ POST        /scratch              controllers.ScratchController.save
 
 GET         /published/:id        controllers.PublishedController.get(id)
 
-GET         /approval/list        controllers.ApprovalController.approvalSummaryList
+GET         /approval             controllers.ApprovalController.approvalSummaryList
 GET         /approval/:id         controllers.ApprovalController.get(id)
 POST        /approval             controllers.ApprovalController.save
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -5,7 +5,7 @@ POST        /scratch              controllers.ScratchController.save
 
 GET         /published/:id        controllers.PublishedController.get(id)
 
-GET         /approval/list        controllers.ApprovalController.listForAdminHomePage
+GET         /approval/list        controllers.ApprovalController.approvalSummaryList
 GET         /approval/:id         controllers.ApprovalController.get(id)
 POST        /approval             controllers.ApprovalController.save
 

--- a/it/data/ExamplePayloads.scala
+++ b/it/data/ExamplePayloads.scala
@@ -93,7 +93,7 @@ object ExamplePayloads {
       |  "meta" : {
       |    "id" : "oct90001",
       |    "title" : "This is the title",
-      |    "status" : "Ready for 2i",
+      |    "status" : "SubmittedFor2iReview",
       |    "dateSubmitted" : {"$date": placeholder}
       |  },
       |  "process" : {
@@ -109,7 +109,7 @@ object ExamplePayloads {
       |  "meta" : {
       |    "id" : "oct90001",
       |    "title" : "This is the title",
-      |    "status" : "Ready for 2i",
+      |    "status" : "SubmittedFor2iReview",
       |    "dateSubmitted" : {"$date": placeholder}
       |  },
       |  "process" : {

--- a/it/data/ExamplePayloads.scala
+++ b/it/data/ExamplePayloads.scala
@@ -81,4 +81,34 @@ object ExamplePayloads {
       |}
     """.stripMargin
   )
+
+  val validApprovalProcessJson: JsValue = Json.parse(
+    """
+      |{
+      |  "meta" : {
+      |    "id" : "oct90001",
+      |    "title" : "This is the title",
+      |    "status" : "Ready for 2i",
+      |    "dateSubmitted" : {"$date": 1500298931016}
+      |  },
+      |  "process" : {
+      |  }
+      |}
+      """.stripMargin
+  )
+  val expectedApprovalProcessJson: JsValue = Json.parse(
+    """
+      |{
+      |  "_id" : "oct90001",
+      |  "meta" : {
+      |    "id" : "oct90001",
+      |    "title" : "This is the title",
+      |    "status" : "Ready for 2i",
+      |    "dateSubmitted" : {"$date": 1500298931016}
+      |  },
+      |  "process" : {
+      |  }
+      |}
+      """.stripMargin
+  )
 }

--- a/it/data/ExamplePayloads.scala
+++ b/it/data/ExamplePayloads.scala
@@ -22,7 +22,7 @@ import play.api.libs.json.{JsValue, Json}
 
 object ExamplePayloads {
 
-  val simpleValidProcess: JsValue = Json.parse(
+  val simpleValidProcessString: String =
     """
       |{
       |  "meta": {
@@ -82,7 +82,8 @@ object ExamplePayloads {
       |  ]
       |}
     """.stripMargin
-  )
+
+  val simpleValidProcess: JsValue = Json.parse(simpleValidProcessString)
 
   val dateSubmitted: LocalDate = LocalDate.of(2020, 3, 3)
   val submittedDateInMilliseconds: Long = dateSubmitted.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
@@ -96,10 +97,11 @@ object ExamplePayloads {
       |    "status" : "SubmittedFor2iReview",
       |    "dateSubmitted" : {"$date": placeholder}
       |  },
-      |  "process" : {
-      |  }
+      |  "process" : processPlaceholder
       |}
-      """.stripMargin.replace("placeholder", submittedDateInMilliseconds.toString)
+      """.stripMargin
+      .replace("placeholder", submittedDateInMilliseconds.toString)
+      .replace("processPlaceholder", simpleValidProcessString)
   )
 
   val expectedApprovalProcessJson: JsValue = Json.parse(
@@ -112,9 +114,10 @@ object ExamplePayloads {
       |    "status" : "SubmittedFor2iReview",
       |    "dateSubmitted" : {"$date": placeholder}
       |  },
-      |  "process" : {
-      |  }
+      |  "process" : processPlaceholder
       |}
-      """.stripMargin.replace("placeholder", submittedDateInMilliseconds.toString)
+      """.stripMargin
+      .replace("placeholder", submittedDateInMilliseconds.toString)
+      .replace("processPlaceholder", simpleValidProcessString)
   )
 }

--- a/it/data/ExamplePayloads.scala
+++ b/it/data/ExamplePayloads.scala
@@ -16,6 +16,8 @@
 
 package data
 
+import java.time.{LocalDate, ZoneOffset}
+
 import play.api.libs.json.{JsValue, Json}
 
 object ExamplePayloads {
@@ -82,6 +84,9 @@ object ExamplePayloads {
     """.stripMargin
   )
 
+  val dateSubmitted: LocalDate = LocalDate.of(2020, 3, 3)
+  val submittedDateInMilliseconds: Long = dateSubmitted.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
+
   val validApprovalProcessJson: JsValue = Json.parse(
     """
       |{
@@ -89,13 +94,14 @@ object ExamplePayloads {
       |    "id" : "oct90001",
       |    "title" : "This is the title",
       |    "status" : "Ready for 2i",
-      |    "dateSubmitted" : {"$date": 1500298931016}
+      |    "dateSubmitted" : {"$date": placeholder}
       |  },
       |  "process" : {
       |  }
       |}
-      """.stripMargin
+      """.stripMargin.replace("placeholder", submittedDateInMilliseconds.toString)
   )
+
   val expectedApprovalProcessJson: JsValue = Json.parse(
     """
       |{
@@ -104,11 +110,11 @@ object ExamplePayloads {
       |    "id" : "oct90001",
       |    "title" : "This is the title",
       |    "status" : "Ready for 2i",
-      |    "dateSubmitted" : {"$date": 1500298931016}
+      |    "dateSubmitted" : {"$date": placeholder}
       |  },
       |  "process" : {
       |  }
       |}
-      """.stripMargin
+      """.stripMargin.replace("placeholder", submittedDateInMilliseconds.toString)
   )
 }

--- a/it/endpoints/GetApprovalProcessISpec.scala
+++ b/it/endpoints/GetApprovalProcessISpec.scala
@@ -34,7 +34,7 @@ class GetApprovalProcessISpec extends IntegrationSpec {
       (json \ "id").as[String]
     }
 
-    val processToSave: JsValue = ExamplePayloads.simpleValidProcess
+    val processToSave: JsValue = ExamplePayloads.validApprovalProcessJson
     lazy val id = populateDatabase(processToSave)
     lazy val request = buildRequest(s"/external-guidance/approval/$id")
     lazy val response: WSResponse = {
@@ -52,7 +52,7 @@ class GetApprovalProcessISpec extends IntegrationSpec {
 
     "return the corresponding JSON in the response" in {
       val json = response.body[JsValue].as[JsObject]
-      json shouldBe processToSave
+      json shouldBe ExamplePayloads.expectedApprovalProcessJson
     }
   }
 
@@ -78,4 +78,37 @@ class GetApprovalProcessISpec extends IntegrationSpec {
       (json \ "code").as[String] shouldBe "NOT_FOUND_ERROR"
     }
   }
+
+  "Calling the approval list endpoint" should {
+
+    def populateDatabase(processToSave: JsValue): String = {
+      lazy val request = buildRequest("/external-guidance/approval")
+
+      val result = await(request.post(processToSave))
+      val json = result.body[JsValue].as[JsObject]
+      (json \ "id").as[String]
+    }
+
+    val processToSave: JsValue = ExamplePayloads.validApprovalProcessJson
+    lazy val id = populateDatabase(processToSave)
+    lazy val request = buildRequest(s"/external-guidance/approval/list")
+    lazy val response: WSResponse = {
+      AuditStub.audit()
+      await(request.get())
+    }
+
+    "return a OK status code" in {
+      response.status shouldBe Status.OK
+    }
+
+    "return content as JSON" in {
+      response.contentType shouldBe ContentTypes.JSON
+    }
+
+//    "return the corresponding JSON in the response" in {
+//      val json = response.body[JsValue].as[JsObject]
+//      json shouldBe ExamplePayloads.expectedApprovalProcessJson
+//    }
+  }
+
 }

--- a/it/endpoints/GetApprovalProcessISpec.scala
+++ b/it/endpoints/GetApprovalProcessISpec.scala
@@ -52,7 +52,7 @@ class GetApprovalProcessISpec extends IntegrationSpec {
 
     "return the corresponding JSON in the response" in {
       val json = response.body[JsValue].as[JsObject]
-      json shouldBe ExamplePayloads.expectedApprovalProcessJson
+      json shouldBe ExamplePayloads.simpleValidProcess
     }
   }
 
@@ -79,9 +79,9 @@ class GetApprovalProcessISpec extends IntegrationSpec {
     }
   }
 
-  "Calling the approval list endpoint" should {
+  "Calling the approval summaries endpoint" should {
 
-    lazy val request = buildRequest(s"/external-guidance/approval/list")
+    lazy val request = buildRequest(s"/external-guidance/approval")
     lazy val response: WSResponse = {
       AuditStub.audit()
       await(request.get())

--- a/it/endpoints/GetApprovalProcessISpec.scala
+++ b/it/endpoints/GetApprovalProcessISpec.scala
@@ -17,7 +17,7 @@ package endpoints
 
 import data.ExamplePayloads
 import play.api.http.{ContentTypes, Status}
-import play.api.libs.json.{JsObject, JsValue}
+import play.api.libs.json.{JsArray, JsObject, JsValue}
 import play.api.libs.ws.WSResponse
 import stubs.AuditStub
 import support.IntegrationSpec
@@ -81,16 +81,6 @@ class GetApprovalProcessISpec extends IntegrationSpec {
 
   "Calling the approval list endpoint" should {
 
-    def populateDatabase(processToSave: JsValue): String = {
-      lazy val request = buildRequest("/external-guidance/approval")
-
-      val result = await(request.post(processToSave))
-      val json = result.body[JsValue].as[JsObject]
-      (json \ "id").as[String]
-    }
-
-    val processToSave: JsValue = ExamplePayloads.validApprovalProcessJson
-    lazy val id = populateDatabase(processToSave)
     lazy val request = buildRequest(s"/external-guidance/approval/list")
     lazy val response: WSResponse = {
       AuditStub.audit()
@@ -105,10 +95,13 @@ class GetApprovalProcessISpec extends IntegrationSpec {
       response.contentType shouldBe ContentTypes.JSON
     }
 
-//    "return the corresponding JSON in the response" in {
-//      val json = response.body[JsValue].as[JsObject]
-//      json shouldBe ExamplePayloads.expectedApprovalProcessJson
-//    }
+    "return the corresponding list as JSON in the response" in {
+      val json = response.body[JsValue]
+      json match {
+        case JsArray(_) => succeed
+        case _ => fail()
+      }
+    }
   }
 
 }

--- a/it/endpoints/PostApprovalProcessISpec.scala
+++ b/it/endpoints/PostApprovalProcessISpec.scala
@@ -27,7 +27,7 @@ class PostApprovalProcessISpec extends IntegrationSpec {
 
   "Calling the approval POST endpoint with a valid payload" should {
 
-    val processToSave: JsValue = ExamplePayloads.simpleValidProcess
+    val processToSave: JsValue = ExamplePayloads.validApprovalProcessJson
     val idToSave = (processToSave \ "meta" \ "id").as[String]
 
     lazy val request = buildRequest("/external-guidance/approval")

--- a/test/controllers/ApprovalControllerSpec.scala
+++ b/test/controllers/ApprovalControllerSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.ContentTypes
-import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -248,19 +248,19 @@ class ApprovalControllerSpec extends WordSpec with Matchers with ScalaFutures wi
 
       trait ValidListTest extends Test {
         MockApprovalService
-          .listForHomePage()
-          .returns(Future.successful(Right(List(approvalProcessSummary))))
+          .approvalSummaryList()
+          .returns(Future.successful(Right(Json.toJson(List(approvalProcessSummary)).as[JsArray])))
 
         lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/list")
       }
 
       "return an OK response" in new ValidListTest {
-        private val result = controller.listForAdminHomePage()(request)
+        private val result = controller.approvalSummaryList()(request)
         status(result) shouldBe OK
       }
 
       "return content as JSON" in new ValidListTest {
-        private val result = controller.listForAdminHomePage()(request)
+        private val result = controller.approvalSummaryList()(request)
         contentType(result) shouldBe Some(ContentTypes.JSON)
       }
 
@@ -276,24 +276,24 @@ class ApprovalControllerSpec extends WordSpec with Matchers with ScalaFutures wi
       trait ErrorGetTest extends Test {
         val expectedErrorCode = "INTERNAL_SERVER_ERROR"
         MockApprovalService
-          .listForHomePage()
+          .approvalSummaryList()
           .returns(Future.successful(Left(Errors(InternalServiceError))))
 
         lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/list")
       }
 
       "return a internal server error response" in new ErrorGetTest {
-        private val result = controller.listForAdminHomePage()(request)
+        private val result = controller.approvalSummaryList()(request)
         status(result) shouldBe INTERNAL_SERVER_ERROR
       }
 
       "return content as JSON" in new ErrorGetTest {
-        private val result = controller.listForAdminHomePage()(request)
+        private val result = controller.approvalSummaryList()(request)
         contentType(result) shouldBe Some(ContentTypes.JSON)
       }
 
       "return an error code of INTERNAL_SERVER_ERROR" in new ErrorGetTest {
-        private val result = controller.listForAdminHomePage()(request)
+        private val result = controller.approvalSummaryList()(request)
         private val data = contentAsJson(result).as[JsObject]
         (data \ "code").as[String] shouldBe expectedErrorCode
       }

--- a/test/controllers/ApprovalControllerSpec.scala
+++ b/test/controllers/ApprovalControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import mocks.MockApprovalService
 import models.errors.{BadRequestError, Errors, InternalServiceError, NotFoundError}
-import models.ocelot.ProcessJson
+import models.{ApprovalProcess, ApprovalProcessJson}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpec}
@@ -28,19 +28,16 @@ import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import services.ApprovalService
+import repositories.formatters.ApprovalProcessFormatter
 
 import scala.concurrent.Future
 
-class ApprovalControllerSpec extends WordSpec with Matchers with ScalaFutures with GuiceOneAppPerSuite with MockFactory with ProcessJson {
+class ApprovalControllerSpec extends WordSpec
+  with Matchers with ScalaFutures with GuiceOneAppPerSuite with MockFactory with ApprovalProcessJson {
 
   private trait Test extends MockApprovalService {
-    val validId: String = "oct90001"
     val invalidId: String = "ext95"
-    val process: JsObject = validOnePageJson.as[JsObject]
     val invalidProcess: JsObject = Json.obj("id" -> "ext0093")
-
-    val mockService: ApprovalService = mock[ApprovalService]
 
     lazy val controller: ApprovalController = new ApprovalController(mockApprovalService, stubControllerComponents())
   }
@@ -52,10 +49,10 @@ class ApprovalControllerSpec extends WordSpec with Matchers with ScalaFutures wi
       trait ValidSaveTest extends Test {
         val expectedId: String = validId
         MockApprovalService
-          .save(process)
+          .save(validApprovalProcessJson)
           .returns(Future.successful(Right(expectedId)))
 
-        lazy val request: FakeRequest[JsValue] = FakeRequest().withBody(process)
+        lazy val request: FakeRequest[JsValue] = FakeRequest().withBody(validApprovalProcessJson)
       }
 
       "return a created response" in new ValidSaveTest {
@@ -137,10 +134,9 @@ class ApprovalControllerSpec extends WordSpec with Matchers with ScalaFutures wi
     "the request is valid" should {
 
       trait ValidGetTest extends Test {
-        val expectedProcess: JsObject = Json.obj("_id" -> validId)
         MockApprovalService
           .getById(validId)
-          .returns(Future.successful(Right(expectedProcess)))
+          .returns(Future.successful(Right(approvalProcess)))
 
         lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
       }
@@ -157,7 +153,8 @@ class ApprovalControllerSpec extends WordSpec with Matchers with ScalaFutures wi
 
       "confirm returned content is a JSON object" in new ValidGetTest {
         private val result = controller.get(validId)(request)
-        contentAsJson(result).as[JsObject] shouldBe expectedProcess
+        val processReturned: ApprovalProcess = contentAsJson(result).as[ApprovalProcess](ApprovalProcessFormatter.mongoFormat)
+        processReturned.id shouldBe approvalProcess.id
       }
     }
 
@@ -245,4 +242,64 @@ class ApprovalControllerSpec extends WordSpec with Matchers with ScalaFutures wi
       }
     }
   }
+
+  "Calling the listForHomePage action" when {
+
+    "the request is valid" should {
+
+      trait ValidListTest extends Test {
+        MockApprovalService
+          .listForHomePage()
+          .returns(Future.successful(Right(List(approvalProcessMeta))))
+
+        lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/list")
+      }
+
+      "return an OK response" in new ValidListTest {
+        private val result = controller.listForAdminHomePage()(request)
+        status(result) shouldBe OK
+      }
+
+      "return content as JSON" in new ValidListTest {
+        private val result = controller.listForAdminHomePage()(request)
+        contentType(result) shouldBe Some(ContentTypes.JSON)
+      }
+
+//      "confirm returned content is a JSON object" in new ValidListTest {
+//        private val result = controller.listForAdminHomePage()(request)
+//        val processReturned: List[ApprovalProcessMeta] = contentAsJson(result).as[List[ApprovalProcessMeta]](ApprovalProcessMetaFormatter.read)
+//        processReturned(0).id shouldBe approvalProcess.id
+//      }
+    }
+
+    "a downstream error occurs" should {
+
+      trait ErrorGetTest extends Test {
+        val expectedErrorCode = "INTERNAL_SERVER_ERROR"
+        MockApprovalService
+          .listForHomePage()
+          .returns(Future.successful(Left(Errors(InternalServiceError))))
+
+        lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/list")
+      }
+
+      "return a internal server error response" in new ErrorGetTest {
+        private val result = controller.listForAdminHomePage()(request)
+        status(result) shouldBe INTERNAL_SERVER_ERROR
+      }
+
+      "return content as JSON" in new ErrorGetTest {
+        private val result = controller.listForAdminHomePage()(request)
+        contentType(result) shouldBe Some(ContentTypes.JSON)
+      }
+
+      "return an error code of INTERNAL_SERVER_ERROR" in new ErrorGetTest {
+        private val result = controller.listForAdminHomePage()(request)
+        private val data = contentAsJson(result).as[JsObject]
+        (data \ "code").as[String] shouldBe expectedErrorCode
+      }
+    }
+  }
+
+
 }

--- a/test/controllers/ApprovalControllerSpec.scala
+++ b/test/controllers/ApprovalControllerSpec.scala
@@ -32,8 +32,7 @@ import repositories.formatters.ApprovalProcessFormatter
 
 import scala.concurrent.Future
 
-class ApprovalControllerSpec extends WordSpec
-  with Matchers with ScalaFutures with GuiceOneAppPerSuite with MockFactory with ApprovalProcessJson {
+class ApprovalControllerSpec extends WordSpec with Matchers with ScalaFutures with GuiceOneAppPerSuite with MockFactory with ApprovalProcessJson {
 
   private trait Test extends MockApprovalService {
     val invalidId: String = "ext95"
@@ -250,7 +249,7 @@ class ApprovalControllerSpec extends WordSpec
       trait ValidListTest extends Test {
         MockApprovalService
           .listForHomePage()
-          .returns(Future.successful(Right(List(approvalProcessMeta))))
+          .returns(Future.successful(Right(List(approvalProcessSummary))))
 
         lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/list")
       }
@@ -300,6 +299,5 @@ class ApprovalControllerSpec extends WordSpec
       }
     }
   }
-
 
 }

--- a/test/controllers/ApprovalControllerSpec.scala
+++ b/test/controllers/ApprovalControllerSpec.scala
@@ -135,7 +135,7 @@ class ApprovalControllerSpec extends WordSpec with Matchers with ScalaFutures wi
       trait ValidGetTest extends Test {
         MockApprovalService
           .getById(validId)
-          .returns(Future.successful(Right(approvalProcess)))
+          .returns(Future.successful(Right(validApprovalProcessJson)))
 
         lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
       }
@@ -242,7 +242,7 @@ class ApprovalControllerSpec extends WordSpec with Matchers with ScalaFutures wi
     }
   }
 
-  "Calling the listForHomePage action" when {
+  "Calling the approvalSummaryList action" when {
 
     "the request is valid" should {
 
@@ -251,7 +251,7 @@ class ApprovalControllerSpec extends WordSpec with Matchers with ScalaFutures wi
           .approvalSummaryList()
           .returns(Future.successful(Right(Json.toJson(List(approvalProcessSummary)).as[JsArray])))
 
-        lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/list")
+        lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
       }
 
       "return an OK response" in new ValidListTest {
@@ -263,12 +263,6 @@ class ApprovalControllerSpec extends WordSpec with Matchers with ScalaFutures wi
         private val result = controller.approvalSummaryList()(request)
         contentType(result) shouldBe Some(ContentTypes.JSON)
       }
-
-//      "confirm returned content is a JSON object" in new ValidListTest {
-//        private val result = controller.listForAdminHomePage()(request)
-//        val processReturned: List[ApprovalProcessMeta] = contentAsJson(result).as[List[ApprovalProcessMeta]](ApprovalProcessMetaFormatter.read)
-//        processReturned(0).id shouldBe approvalProcess.id
-//      }
     }
 
     "a downstream error occurs" should {
@@ -279,7 +273,7 @@ class ApprovalControllerSpec extends WordSpec with Matchers with ScalaFutures wi
           .approvalSummaryList()
           .returns(Future.successful(Left(Errors(InternalServiceError))))
 
-        lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/list")
+        lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "")
       }
 
       "return a internal server error response" in new ErrorGetTest {

--- a/test/mocks/MockApprovalRepository.scala
+++ b/test/mocks/MockApprovalRepository.scala
@@ -41,8 +41,8 @@ trait MockApprovalRepository extends MockFactory {
         .expects(id)
     }
 
-    def listForHomePage(): CallHandler[Future[RequestOutcome[List[ApprovalProcessSummary]]]] = {
-      (mockApprovalRepository.listForHomePage: () => Future[RequestOutcome[List[ApprovalProcessSummary]]])
+    def approvalSummaryList(): CallHandler[Future[RequestOutcome[List[ApprovalProcessSummary]]]] = {
+      (mockApprovalRepository.approvalSummaryList: () => Future[RequestOutcome[List[ApprovalProcessSummary]]])
         .expects()
     }
 

--- a/test/mocks/MockApprovalRepository.scala
+++ b/test/mocks/MockApprovalRepository.scala
@@ -16,7 +16,7 @@
 
 package mocks
 
-import models.{ApprovalProcess, RequestOutcome}
+import models.{ApprovalProcess, ApprovalProcessSummary, RequestOutcome}
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import repositories.ApprovalRepository
@@ -41,8 +41,8 @@ trait MockApprovalRepository extends MockFactory {
         .expects(id)
     }
 
-    def listForHomePage(): CallHandler[Future[RequestOutcome[List[ApprovalProcess]]]] = {
-      (mockApprovalRepository.listForHomePage: () => Future[RequestOutcome[List[ApprovalProcess]]])
+    def listForHomePage(): CallHandler[Future[RequestOutcome[List[ApprovalProcessSummary]]]] = {
+      (mockApprovalRepository.listForHomePage: () => Future[RequestOutcome[List[ApprovalProcessSummary]]])
         .expects()
     }
 

--- a/test/mocks/MockApprovalRepository.scala
+++ b/test/mocks/MockApprovalRepository.scala
@@ -41,10 +41,8 @@ trait MockApprovalRepository extends MockFactory {
         .expects(id)
     }
 
-
     def listForHomePage(): CallHandler[Future[RequestOutcome[List[ApprovalProcess]]]] = {
-      (mockApprovalRepository
-        .listForHomePage: () => Future[RequestOutcome[List[ApprovalProcess]]])
+      (mockApprovalRepository.listForHomePage: () => Future[RequestOutcome[List[ApprovalProcess]]])
         .expects()
     }
 

--- a/test/mocks/MockApprovalRepository.scala
+++ b/test/mocks/MockApprovalRepository.scala
@@ -19,6 +19,7 @@ package mocks
 import models.{ApprovalProcess, ApprovalProcessSummary, RequestOutcome}
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
+import play.api.libs.json.JsObject
 import repositories.ApprovalRepository
 
 import scala.concurrent.Future
@@ -35,7 +36,7 @@ trait MockApprovalRepository extends MockFactory {
         .expects(id, process)
     }
 
-    def getById(id: String): CallHandler[Future[RequestOutcome[ApprovalProcess]]] = {
+    def getById(id: String): CallHandler[Future[RequestOutcome[JsObject]]] = {
       (mockApprovalRepository
         .getById(_: String))
         .expects(id)

--- a/test/mocks/MockApprovalRepository.scala
+++ b/test/mocks/MockApprovalRepository.scala
@@ -16,10 +16,9 @@
 
 package mocks
 
-import models.RequestOutcome
+import models.{ApprovalProcess, RequestOutcome}
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
-import play.api.libs.json.JsObject
 import repositories.ApprovalRepository
 
 import scala.concurrent.Future
@@ -30,16 +29,23 @@ trait MockApprovalRepository extends MockFactory {
 
   object MockApprovalRepository {
 
-    def update(id: String, process: JsObject): CallHandler[Future[RequestOutcome[String]]] = {
+    def update(id: String, process: ApprovalProcess): CallHandler[Future[RequestOutcome[String]]] = {
       (mockApprovalRepository
-        .update(_: String, _: JsObject))
+        .update(_: String, _: ApprovalProcess))
         .expects(id, process)
     }
 
-    def getById(id: String): CallHandler[Future[RequestOutcome[JsObject]]] = {
+    def getById(id: String): CallHandler[Future[RequestOutcome[ApprovalProcess]]] = {
       (mockApprovalRepository
         .getById(_: String))
         .expects(id)
+    }
+
+
+    def listForHomePage(): CallHandler[Future[RequestOutcome[List[ApprovalProcess]]]] = {
+      (mockApprovalRepository
+        .listForHomePage: () => Future[RequestOutcome[List[ApprovalProcess]]])
+        .expects()
     }
 
   }

--- a/test/mocks/MockApprovalService.scala
+++ b/test/mocks/MockApprovalService.scala
@@ -16,7 +16,7 @@
 
 package mocks
 
-import models.RequestOutcome
+import models.{ApprovalProcess, ApprovalProcessMeta, RequestOutcome}
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import play.api.libs.json.JsObject
@@ -29,7 +29,7 @@ trait MockApprovalService extends MockFactory {
 
   object MockApprovalService {
 
-    def getById(id: String): CallHandler[Future[RequestOutcome[JsObject]]] = {
+    def getById(id: String): CallHandler[Future[RequestOutcome[ApprovalProcess]]] = {
       (mockApprovalService
         .getById(_: String))
         .expects(id)
@@ -41,6 +41,11 @@ trait MockApprovalService extends MockFactory {
         .expects(process)
     }
 
-  }
+    def listForHomePage(): CallHandler[Future[RequestOutcome[List[ApprovalProcessMeta]]]] = {
+      (mockApprovalService
+        .listForHomePage: () => Future[RequestOutcome[List[ApprovalProcessMeta]]])
+        .expects()
+    }
 
+  }
 }

--- a/test/mocks/MockApprovalService.scala
+++ b/test/mocks/MockApprovalService.scala
@@ -16,7 +16,7 @@
 
 package mocks
 
-import models.{ApprovalProcess, ApprovalProcessMeta, RequestOutcome}
+import models.{ApprovalProcess, ApprovalProcessSummary, RequestOutcome}
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import play.api.libs.json.JsObject
@@ -41,9 +41,8 @@ trait MockApprovalService extends MockFactory {
         .expects(process)
     }
 
-    def listForHomePage(): CallHandler[Future[RequestOutcome[List[ApprovalProcessMeta]]]] = {
-      (mockApprovalService
-        .listForHomePage: () => Future[RequestOutcome[List[ApprovalProcessMeta]]])
+    def listForHomePage(): CallHandler[Future[RequestOutcome[List[ApprovalProcessSummary]]]] = {
+      (mockApprovalService.listForHomePage: () => Future[RequestOutcome[List[ApprovalProcessSummary]]])
         .expects()
     }
 

--- a/test/mocks/MockApprovalService.scala
+++ b/test/mocks/MockApprovalService.scala
@@ -16,7 +16,7 @@
 
 package mocks
 
-import models.{ApprovalProcess, RequestOutcome}
+import models.RequestOutcome
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import play.api.libs.json.{JsArray, JsObject}
@@ -29,7 +29,7 @@ trait MockApprovalService extends MockFactory {
 
   object MockApprovalService {
 
-    def getById(id: String): CallHandler[Future[RequestOutcome[ApprovalProcess]]] = {
+    def getById(id: String): CallHandler[Future[RequestOutcome[JsObject]]] = {
       (mockApprovalService
         .getById(_: String))
         .expects(id)

--- a/test/mocks/MockApprovalService.scala
+++ b/test/mocks/MockApprovalService.scala
@@ -16,10 +16,10 @@
 
 package mocks
 
-import models.{ApprovalProcess, ApprovalProcessSummary, RequestOutcome}
+import models.{ApprovalProcess, RequestOutcome}
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
-import play.api.libs.json.JsObject
+import play.api.libs.json.{JsArray, JsObject}
 import services.ApprovalService
 
 import scala.concurrent.Future
@@ -41,8 +41,8 @@ trait MockApprovalService extends MockFactory {
         .expects(process)
     }
 
-    def listForHomePage(): CallHandler[Future[RequestOutcome[List[ApprovalProcessSummary]]]] = {
-      (mockApprovalService.listForHomePage: () => Future[RequestOutcome[List[ApprovalProcessSummary]]])
+    def approvalSummaryList(): CallHandler[Future[RequestOutcome[JsArray]]] = {
+      (mockApprovalService.approvalSummaryList: () => Future[RequestOutcome[JsArray]])
         .expects()
     }
 

--- a/test/models/ApprovalProcessJson.scala
+++ b/test/models/ApprovalProcessJson.scala
@@ -16,20 +16,23 @@
 
 package models
 
-import org.joda.time.{DateTimeZone, LocalDateTime}
+import java.time.{LocalDate, ZoneId, ZoneOffset}
+
 import play.api.libs.json.{JsObject, Json}
 
 trait ApprovalProcessJson {
 
   val validId = "oct90001"
-  val dateSubmitted: LocalDateTime = LocalDateTime.now()
-  val submittedDateInMilliseconds: Long = dateSubmitted.toDateTime(DateTimeZone.UTC).getMillis
+  val dateSubmitted: LocalDate = LocalDate.of(2020, 3, 3)
+  val submittedDateInMilliseconds: Long = dateSubmitted.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
 
   val approvalProcessMeta: ApprovalProcessMeta = ApprovalProcessMeta("oct90001", "This is the title", "Ready for 2i", dateSubmitted)
   val approvalProcess: ApprovalProcess = ApprovalProcess(validId, approvalProcessMeta, Json.obj())
+  val approvalProcessSummary: ApprovalProcessSummary = ApprovalProcessSummary("oct90001", "This is the title", dateSubmitted, "Ready for 2i")
 
-  val validApprovalProcessJson: JsObject = Json.parse(
-    """
+  val validApprovalProcessJson: JsObject = Json
+    .parse(
+      """
       |{
       |  "_id" : "oct90001",
       |  "meta" : {
@@ -42,10 +45,12 @@ trait ApprovalProcessJson {
       |  }
       |}
     """.stripMargin.replace("placeholder", submittedDateInMilliseconds.toString)
-  ).as[JsObject]
+    )
+    .as[JsObject]
 
-  val expectedReturnedApprovalProcessJson: JsObject = Json.parse(
-    """
+  val expectedReturnedApprovalProcessJson: JsObject = Json
+    .parse(
+      """
       |{
       |  "id" : "oct90001",
       |  "meta" : {
@@ -58,6 +63,7 @@ trait ApprovalProcessJson {
       |  }
       |}
     """.stripMargin
-  ).as[JsObject]
+    )
+    .as[JsObject]
 
 }

--- a/test/models/ApprovalProcessJson.scala
+++ b/test/models/ApprovalProcessJson.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import org.joda.time.{DateTimeZone, LocalDateTime}
+import play.api.libs.json.{JsObject, Json}
+
+trait ApprovalProcessJson {
+
+  val validId = "oct90001"
+  val dateSubmitted: LocalDateTime = LocalDateTime.now()
+  val submittedDateInMilliseconds: Long = dateSubmitted.toDateTime(DateTimeZone.UTC).getMillis
+
+  val approvalProcessMeta: ApprovalProcessMeta = ApprovalProcessMeta("oct90001", "This is the title", "Ready for 2i", dateSubmitted)
+  val approvalProcess: ApprovalProcess = ApprovalProcess(validId, approvalProcessMeta, Json.obj())
+
+  val validApprovalProcessJson: JsObject = Json.parse(
+    """
+      |{
+      |  "_id" : "oct90001",
+      |  "meta" : {
+      |    "id" : "oct90001",
+      |    "title" : "This is the title",
+      |    "status" : "Ready for 2i",
+      |    "dateSubmitted" : {"$date": placeholder}
+      |  },
+      |  "process" : {
+      |  }
+      |}
+    """.stripMargin.replace("placeholder", submittedDateInMilliseconds.toString)
+  ).as[JsObject]
+
+  val expectedReturnedApprovalProcessJson: JsObject = Json.parse(
+    """
+      |{
+      |  "id" : "oct90001",
+      |  "meta" : {
+      |    "id" : "oct90001",
+      |    "title" : "This is the title",
+      |    "status" : "Ready for 2i",
+      |    "dateSubmitted" : {"$date": 1500298931016}
+      |  },
+      |  "process" : {
+      |  }
+      |}
+    """.stripMargin
+  ).as[JsObject]
+
+}

--- a/test/models/ApprovalProcessJson.scala
+++ b/test/models/ApprovalProcessJson.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import java.time.{LocalDate, ZoneId, ZoneOffset}
+import java.time.{LocalDate, ZoneOffset}
 
 import play.api.libs.json.{JsObject, Json}
 
@@ -26,9 +26,9 @@ trait ApprovalProcessJson {
   val dateSubmitted: LocalDate = LocalDate.of(2020, 3, 3)
   val submittedDateInMilliseconds: Long = dateSubmitted.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
 
-  val approvalProcessMeta: ApprovalProcessMeta = ApprovalProcessMeta("oct90001", "This is the title", "Ready for 2i", dateSubmitted)
+  val approvalProcessMeta: ApprovalProcessMeta = ApprovalProcessMeta("oct90001", "This is the title", "SubmittedFor2iReview", dateSubmitted)
   val approvalProcess: ApprovalProcess = ApprovalProcess(validId, approvalProcessMeta, Json.obj())
-  val approvalProcessSummary: ApprovalProcessSummary = ApprovalProcessSummary("oct90001", "This is the title", dateSubmitted, "Ready for 2i")
+  val approvalProcessSummary: ApprovalProcessSummary = ApprovalProcessSummary("oct90001", "This is the title", dateSubmitted, "SubmittedFor2iReview")
 
   val validApprovalProcessJson: JsObject = Json
     .parse(
@@ -38,31 +38,13 @@ trait ApprovalProcessJson {
       |  "meta" : {
       |    "id" : "oct90001",
       |    "title" : "This is the title",
-      |    "status" : "Ready for 2i",
+      |    "status" : "SubmittedFor2iReview",
       |    "dateSubmitted" : {"$date": placeholder}
       |  },
       |  "process" : {
       |  }
       |}
     """.stripMargin.replace("placeholder", submittedDateInMilliseconds.toString)
-    )
-    .as[JsObject]
-
-  val expectedReturnedApprovalProcessJson: JsObject = Json
-    .parse(
-      """
-      |{
-      |  "id" : "oct90001",
-      |  "meta" : {
-      |    "id" : "oct90001",
-      |    "title" : "This is the title",
-      |    "status" : "Ready for 2i",
-      |    "dateSubmitted" : {"$date": 1500298931016}
-      |  },
-      |  "process" : {
-      |  }
-      |}
-    """.stripMargin
     )
     .as[JsObject]
 

--- a/test/repositories/formatters/ApprovalProcessFormatterSpec.scala
+++ b/test/repositories/formatters/ApprovalProcessFormatterSpec.scala
@@ -17,24 +17,10 @@
 package repositories.formatters
 
 import base.UnitSpec
-import models.ApprovalProcess
-import play.api.libs.json.{JsError, JsObject, JsSuccess, Json}
+import models.{ApprovalProcess, ApprovalProcessJson}
+import play.api.libs.json.{JsError, JsSuccess, JsValue, Json}
 
-class ApprovalProcessFormatterSpec extends UnitSpec {
-
-  private val process: JsObject = Json.obj()
-  private val id: String = "ext90002"
-
-  private val approvalProcess: ApprovalProcess = ApprovalProcess(id, process)
-
-  private val json = Json.parse(
-    s"""
-       |{
-       | "_id": "$id",
-       | "process": {}
-       |}
-       |""".stripMargin
-  )
+class ApprovalProcessFormatterSpec extends UnitSpec with ApprovalProcessJson {
 
   private val invalidJson = Json.parse("{}")
 
@@ -42,7 +28,7 @@ class ApprovalProcessFormatterSpec extends UnitSpec {
 
     "Result in a successful conversion for valid JSON" in {
 
-      json.validate[ApprovalProcess](ApprovalProcessFormatter.mongoFormat) match {
+      validApprovalProcessJson.validate[ApprovalProcess](ApprovalProcessFormatter.mongoFormat) match {
         case JsSuccess(result, _) if result == approvalProcess => succeed
         case JsSuccess(_, _) => fail("Deserializing valid JSON did not create correct process")
         case _ => fail("Unable to parse valid Json")
@@ -62,8 +48,8 @@ class ApprovalProcessFormatterSpec extends UnitSpec {
   "Serializing an approval process into JSON" should {
 
     "Generate the expected JSON" in {
-      val result = Json.toJson(approvalProcess)(ApprovalProcessFormatter.mongoFormat)
-      result shouldBe json
+      val result: JsValue = Json.toJson(approvalProcess)(ApprovalProcessFormatter.mongoFormat)
+      result shouldBe validApprovalProcessJson.as[JsValue]
     }
   }
 

--- a/test/services/ApprovalServiceSpec.scala
+++ b/test/services/ApprovalServiceSpec.scala
@@ -142,7 +142,7 @@ class ApprovalServiceSpec extends UnitSpec with MockFactory {
     "there are entries to return" should {
       "return a List of approval processes" in new Test {
 
-        val expected: RequestOutcome[List[ApprovalProcess]] = Right(List(approvalProcess))
+        val expected: RequestOutcome[List[ApprovalProcessSummary]] = Right(List(approvalProcessSummary))
 
         MockApprovalRepository
           .listForHomePage()
@@ -152,9 +152,9 @@ class ApprovalServiceSpec extends UnitSpec with MockFactory {
           case Right(list) =>
             list.size shouldBe 1
             val entry = list.head
-            entry.id shouldBe approvalProcess.id
-            entry.title shouldBe approvalProcess.meta.title
-            entry.title shouldBe approvalProcess.meta.title
+            entry.id shouldBe approvalProcessSummary.id
+            entry.title shouldBe approvalProcessSummary.title
+            entry.status shouldBe approvalProcessSummary.status
           case _ => fail
         }
       }
@@ -163,7 +163,7 @@ class ApprovalServiceSpec extends UnitSpec with MockFactory {
     "there are no processes in the database" should {
       "return an empty list" in new Test {
 
-        val expected: RequestOutcome[List[ApprovalProcess]] = Right(List())
+        val expected: RequestOutcome[List[ApprovalProcessSummary]] = Right(List())
         val returnedList: RequestOutcome[List[ApprovalProcessSummary]] = Right(List())
 
         MockApprovalRepository
@@ -179,7 +179,7 @@ class ApprovalServiceSpec extends UnitSpec with MockFactory {
     "the repository reports a database error" should {
       "return an internal server error" in new Test {
 
-        val repositoryError: RequestOutcome[List[ApprovalProcess]] = Left(Errors(DatabaseError))
+        val repositoryError: RequestOutcome[List[ApprovalProcessSummary]] = Left(Errors(DatabaseError))
         val expected: RequestOutcome[List[ApprovalProcessSummary]] = Left(Errors(InternalServiceError))
 
         MockApprovalRepository

--- a/test/services/ApprovalServiceSpec.scala
+++ b/test/services/ApprovalServiceSpec.scala
@@ -18,11 +18,11 @@ package services
 
 import base.UnitSpec
 import mocks.MockApprovalRepository
+import models.ApprovalProcessSummary._
 import models.errors._
-import models.{ApprovalProcess, ApprovalProcessJson, ApprovalProcessSummary, RequestOutcome}
+import models.{ApprovalProcessJson, ApprovalProcessSummary, RequestOutcome}
 import org.scalamock.scalatest.MockFactory
 import play.api.libs.json.{JsArray, JsObject, Json}
-import models.ApprovalProcessSummary._
 
 import scala.concurrent.Future
 
@@ -41,7 +41,7 @@ class ApprovalServiceSpec extends UnitSpec with MockFactory {
     "the ID identifies a valid process" should {
       "return a JSON representing the submitted ocelot process" in new Test {
 
-        val expected: RequestOutcome[ApprovalProcess] = Right(approvalProcess)
+        val expected: RequestOutcome[JsObject] = Right(validApprovalProcessJson)
 
         MockApprovalRepository
           .getById(validId)
@@ -56,7 +56,7 @@ class ApprovalServiceSpec extends UnitSpec with MockFactory {
     "the ID cannot be matched to a submitted process" should {
       "return a not found response" in new Test {
 
-        val expected: RequestOutcome[ApprovalProcess] = Left(Errors(NotFoundError))
+        val expected: RequestOutcome[JsObject] = Left(Errors(NotFoundError))
 
         MockApprovalRepository
           .getById(validId)
@@ -71,8 +71,8 @@ class ApprovalServiceSpec extends UnitSpec with MockFactory {
     "the repository reports a database error" should {
       "return an internal server error" in new Test {
 
-        val repositoryError: RequestOutcome[ApprovalProcess] = Left(Errors(DatabaseError))
-        val expected: RequestOutcome[ApprovalProcess] = Left(Errors(InternalServiceError))
+        val repositoryError: RequestOutcome[JsObject] = Left(Errors(DatabaseError))
+        val expected: RequestOutcome[JsObject] = Left(Errors(InternalServiceError))
 
         MockApprovalRepository
           .getById(validId)
@@ -139,7 +139,7 @@ class ApprovalServiceSpec extends UnitSpec with MockFactory {
     }
   }
 
-  "Calling the listForHomePage method" when {
+  "Calling the approvalSummaryList method" when {
     "there are entries to return" should {
       "return a List of approval processes" in new Test {
 

--- a/test/services/ApprovalServiceSpec.scala
+++ b/test/services/ApprovalServiceSpec.scala
@@ -18,8 +18,8 @@ package services
 
 import base.UnitSpec
 import mocks.MockApprovalRepository
-import models.{ApprovalProcess, ApprovalProcessJson, ApprovalProcessMeta, RequestOutcome}
 import models.errors._
+import models.{ApprovalProcess, ApprovalProcessJson, ApprovalProcessSummary, RequestOutcome}
 import org.scalamock.scalatest.MockFactory
 import play.api.libs.json.{JsObject, Json}
 
@@ -138,7 +138,6 @@ class ApprovalServiceSpec extends UnitSpec with MockFactory {
     }
   }
 
-
   "Calling the listForHomePage method" when {
     "there are entries to return" should {
       "return a List of approval processes" in new Test {
@@ -165,7 +164,7 @@ class ApprovalServiceSpec extends UnitSpec with MockFactory {
       "return an empty list" in new Test {
 
         val expected: RequestOutcome[List[ApprovalProcess]] = Right(List())
-        val returnedList: RequestOutcome[List[ApprovalProcessMeta]] = Right(List())
+        val returnedList: RequestOutcome[List[ApprovalProcessSummary]] = Right(List())
 
         MockApprovalRepository
           .listForHomePage()
@@ -181,7 +180,7 @@ class ApprovalServiceSpec extends UnitSpec with MockFactory {
       "return an internal server error" in new Test {
 
         val repositoryError: RequestOutcome[List[ApprovalProcess]] = Left(Errors(DatabaseError))
-        val expected: RequestOutcome[List[ApprovalProcess]] = Left(Errors(InternalServiceError))
+        val expected: RequestOutcome[List[ApprovalProcessSummary]] = Left(Errors(InternalServiceError))
 
         MockApprovalRepository
           .listForHomePage()
@@ -193,6 +192,5 @@ class ApprovalServiceSpec extends UnitSpec with MockFactory {
       }
     }
   }
-
 
 }


### PR DESCRIPTION
New endpoint for manage front end to use to retrieve summary list of approval processes
Also includes the code for EG-421 to save the status in the database (initial meta structure created but likely to change once we know more requirements)