### PR TITLE
EG-489 Update ApprovalProcess save to take in an ocelot Process

### DIFF
--- a/app/controllers/ProcessReviewController.scala
+++ b/app/controllers/ProcessReviewController.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.play.bootstrap.controller.BackendController
 import scala.concurrent.ExecutionContext.Implicits.global
 
 @Singleton
-class ProcessReviewController @Inject()(reviewService: ReviewService, cc: ControllerComponents) extends BackendController(cc) {
+class ProcessReviewController @Inject() (reviewService: ReviewService, cc: ControllerComponents) extends BackendController(cc) {
 
   def approval2iReviewInfo(id: String): Action[AnyContent] = Action.async { _ =>
     reviewService.approval2iReviewInfo(id).map {

--- a/app/models/ApprovalProcess.scala
+++ b/app/models/ApprovalProcess.scala
@@ -18,4 +18,4 @@ package models
 
 import play.api.libs.json.JsObject
 
-case class ApprovalProcess(id: String, meta: ApprovalProcessMeta, process: JsObject)
+case class ApprovalProcess(id: String, meta: ApprovalProcessMeta, process: JsObject, version: Int = 1)

--- a/app/models/ApprovalProcessMeta.scala
+++ b/app/models/ApprovalProcessMeta.scala
@@ -16,6 +16,12 @@
 
 package models
 
-import java.time.LocalDate
+import java.time.{LocalDate, LocalDateTime}
 
-case class ApprovalProcessMeta(id: String, title: String, status: String, dateSubmitted: LocalDate)
+case class ApprovalProcessMeta(
+    id: String,
+    title: String,
+    status: String = "ReadyFor2iReview",
+    dateSubmitted: LocalDate = LocalDate.now(),
+    lastModified: LocalDateTime = LocalDateTime.now()
+)

--- a/app/models/MongoDateTimeFormats.scala
+++ b/app/models/MongoDateTimeFormats.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import java.time.{Instant, LocalDate, ZoneOffset}
+import java.time.{Instant, LocalDate, LocalDateTime, ZoneOffset}
 
 import play.api.libs.json._
 
@@ -32,7 +32,18 @@ trait MongoDateTimeFormats {
       "$date" -> localDate.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
     )
 
+  implicit val localDateTimeRead: Reads[LocalDateTime] =
+    (__ \ "$date").read[Long].map { millis =>
+      Instant.ofEpochMilli(millis).atZone(ZoneOffset.UTC).toLocalDateTime
+    }
+
+  implicit val localDateTimeWrite: Writes[LocalDateTime] = (localDateTime: LocalDateTime) =>
+    Json.obj(
+      "$date" -> localDateTime.toEpochSecond(ZoneOffset.UTC) * 1000
+    )
+
   implicit val localDateFormats: Format[LocalDate] = Format(localDateRead, localDateWrite)
+  implicit val localDateTimeFormats: Format[LocalDateTime] = Format(localDateTimeRead, localDateTimeWrite)
 
 }
 object MongoDateTimeFormats extends MongoDateTimeFormats

--- a/app/models/errors/Error.scala
+++ b/app/models/errors/Error.scala
@@ -43,10 +43,10 @@ object NotFoundError
     )
 
 object StaleDataError
-  extends Error(
-    "STALE_DATA_ERROR",
-    "The resource requested has been changed."
-  )
+    extends Error(
+      "STALE_DATA_ERROR",
+      "The resource requested has been changed."
+    )
 
 object BadRequestError
     extends Error(

--- a/app/repositories/ApprovalRepository.scala
+++ b/app/repositories/ApprovalRepository.scala
@@ -31,7 +31,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 trait ApprovalRepository {
-  def update(id: String, process: ApprovalProcess): Future[RequestOutcome[String]]
+  def update(process: ApprovalProcess): Future[RequestOutcome[String]]
   def getById(id: String): Future[RequestOutcome[JsObject]]
   def approvalSummaryList(): Future[RequestOutcome[List[ApprovalProcessSummary]]]
 }
@@ -46,21 +46,21 @@ class ApprovalRepositoryImpl @Inject() (implicit mongoComponent: ReactiveMongoCo
     )
     with ApprovalRepository {
 
-  def update(id: String, process: ApprovalProcess): Future[RequestOutcome[String]] = {
+  def update(process: ApprovalProcess): Future[RequestOutcome[String]] = {
 
-    logger.info(s"Saving process $id to collection $collectionName")
-    val selector = Json.obj("_id" -> id)
+    logger.info(s"Saving process ${process.id} to collection $collectionName")
+    val selector = Json.obj("_id" -> process.id)
     val jsonProcess = Json.toJsObject(process)(ApprovalProcessFormatter.mongoFormat)
 
     this
       .findAndUpdate(selector, jsonProcess, upsert = true)
       .map { _ =>
-        Right(id)
+        Right(process.id)
       }
       //$COVERAGE-OFF$
       .recover {
         case error =>
-          logger.error(s"Attempt to persist process $id to collection $collectionName failed with error : ${error.getMessage}")
+          logger.error(s"Attempt to persist process ${process.id} to collection $collectionName failed with error : ${error.getMessage}")
           Left(Errors(DatabaseError))
       }
     //$COVERAGE-ON$

--- a/app/repositories/ApprovalRepository.scala
+++ b/app/repositories/ApprovalRepository.scala
@@ -16,8 +16,6 @@
 
 package repositories
 
-import java.time.LocalDateTime
-
 import javax.inject.{Inject, Singleton}
 import models.errors.{DatabaseError, Errors, NotFoundError}
 import models.{ApprovalProcess, ApprovalProcessSummary, RequestOutcome}
@@ -54,8 +52,7 @@ class ApprovalRepositoryImpl @Inject() (implicit mongoComponent: ReactiveMongoCo
     logger.info(s"Saving process ${approvalProcess.id} to collection $collectionName")
     val selector = Json.obj("_id" -> approvalProcess.id)
     val metaJson = Json.toJson(approvalProcess.meta)
-    val modifier = Json.obj("$inc" -> Json.obj("version" -> 1),
-      "$set" -> Json.obj("meta" -> metaJson, "process" -> approvalProcess.process))
+    val modifier = Json.obj("$inc" -> Json.obj("version" -> 1), "$set" -> Json.obj("meta" -> metaJson, "process" -> approvalProcess.process))
 
     this
       .findAndUpdate(selector, modifier, upsert = true)

--- a/app/repositories/formatters/ApprovalProcessFormatter.scala
+++ b/app/repositories/formatters/ApprovalProcessFormatter.scala
@@ -28,13 +28,15 @@ object ApprovalProcessFormatter {
       id <- (json \ "_id").validateOpt[String]
       meta <- (json \ "meta").validate[ApprovalProcessMeta]
       process <- (json \ "process").validate[JsObject]
-    } yield ApprovalProcess(id.getOrElse(meta.id), meta, process)
+      version <- (json \ "version").validateOpt[Int]
+    } yield ApprovalProcess(id.getOrElse(meta.id), meta, process, version.getOrElse(1))
 
   val write: ApprovalProcess => JsObject = approvalProcess =>
     Json.obj(
       "_id" -> approvalProcess.id,
       "meta" -> Json.toJson(approvalProcess.meta),
-      "process" -> Json.toJson(approvalProcess.process)
+      "process" -> Json.toJson(approvalProcess.process),
+      "version" -> approvalProcess.version
     )
 
   implicit val mongoFormat: OFormat[ApprovalProcess] = OFormat(read, write)

--- a/app/repositories/formatters/ApprovalProcessMetaFormatter.scala
+++ b/app/repositories/formatters/ApprovalProcessMetaFormatter.scala
@@ -16,7 +16,7 @@
 
 package repositories.formatters
 
-import java.time.LocalDate
+import java.time.{LocalDate, LocalDateTime}
 
 import models.{ApprovalProcessMeta, MongoDateTimeFormats}
 import play.api.libs.json._
@@ -24,6 +24,7 @@ import play.api.libs.json._
 object ApprovalProcessMetaFormatter {
 
   implicit val dateFormat: Format[LocalDate] = MongoDateTimeFormats.localDateFormats
+  implicit val dateTimeFormat: Format[LocalDateTime] = MongoDateTimeFormats.localDateTimeFormats
 
   val read: JsValue => JsResult[ApprovalProcessMeta] = json =>
     for {
@@ -31,14 +32,16 @@ object ApprovalProcessMetaFormatter {
       status <- (json \ "status").validate[String]
       title <- (json \ "title").validate[String]
       dateSubmitted <- (json \ "dateSubmitted").validate[LocalDate]
-    } yield ApprovalProcessMeta(id, title, status, dateSubmitted)
+      lastModified <- (json \ "lastModified").validateOpt[LocalDateTime]
+    } yield ApprovalProcessMeta(id, title, status, dateSubmitted, lastModified.getOrElse(LocalDateTime.now()))
 
   val write: ApprovalProcessMeta => JsObject = meta =>
     Json.obj(
       "id" -> meta.id,
       "status" -> meta.status,
       "title" -> meta.title,
-      "dateSubmitted" -> meta.dateSubmitted
+      "dateSubmitted" -> meta.dateSubmitted,
+      "lastModified" -> meta.lastModified
     )
 
   val mongoFormat: OFormat[ApprovalProcessMeta] = OFormat(read, write)

--- a/app/repositories/formatters/ApprovalProcessMetaFormatter.scala
+++ b/app/repositories/formatters/ApprovalProcessMetaFormatter.scala
@@ -44,5 +44,5 @@ object ApprovalProcessMetaFormatter {
       "lastModified" -> meta.lastModified
     )
 
-  val mongoFormat: OFormat[ApprovalProcessMeta] = OFormat(read, write)
+  implicit val mongoFormat: OFormat[ApprovalProcessMeta] = OFormat(read, write)
 }

--- a/app/services/ApprovalService.scala
+++ b/app/services/ApprovalService.scala
@@ -42,12 +42,7 @@ class ApprovalService @Inject() (repository: ApprovalRepository) {
     }
 
     def createApprovalProcess(process: Process): ApprovalProcess = {
-      ApprovalProcess(
-        process.meta.id,
-        ApprovalProcessMeta(
-          process.meta.id,
-          process.meta.title),
-        jsonProcess)
+      ApprovalProcess(process.meta.id, ApprovalProcessMeta(process.meta.id, process.meta.title), jsonProcess)
     }
 
     jsonProcess.validate[Process] match {

--- a/app/services/ApprovalService.scala
+++ b/app/services/ApprovalService.scala
@@ -18,11 +18,11 @@ package services
 
 import javax.inject.{Inject, Singleton}
 import models.errors.{BadRequestError, Errors, InternalServiceError, NotFoundError}
-import models.{ApprovalProcess, RequestOutcome}
+import models.ocelot.Process
+import models.{ApprovalProcess, ApprovalProcessMeta, RequestOutcome}
 import play.api.Logger
 import play.api.libs.json._
 import repositories.ApprovalRepository
-import repositories.formatters.ApprovalProcessFormatter.mongoFormat
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -32,18 +32,27 @@ class ApprovalService @Inject() (repository: ApprovalRepository) {
 
   val logger: Logger = Logger(this.getClass)
 
-  def save(approvalProcess: JsObject): Future[RequestOutcome[String]] = {
+  def save(jsonProcess: JsObject): Future[RequestOutcome[String]] = {
 
-    def saveProcess(process: ApprovalProcess): Future[RequestOutcome[String]] = {
-      repository.update(process.meta.id, process) map {
+    def saveProcess(approvalProcess: ApprovalProcess): Future[RequestOutcome[String]] = {
+      repository.update(approvalProcess) map {
         case Left(_) => Left(Errors(InternalServiceError))
         case result => result
       }
     }
 
-    approvalProcess.validate[ApprovalProcess] match {
+    def createApprovalProcess(process: Process): ApprovalProcess = {
+      ApprovalProcess(
+        process.meta.id,
+        ApprovalProcessMeta(
+          process.meta.id,
+          process.meta.title),
+        jsonProcess)
+    }
+
+    jsonProcess.validate[Process] match {
       case JsSuccess(process, _) =>
-        saveProcess(process)
+        saveProcess(createApprovalProcess(process))
       case JsError(errors) =>
         logger.error(s"Parsing process failed with the following error(s): $errors")
         Future { Left(Errors(BadRequestError)) }

--- a/app/services/ReviewService.scala
+++ b/app/services/ReviewService.scala
@@ -26,22 +26,26 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 @Singleton
-class ReviewService @Inject()() {
+class ReviewService @Inject() () {
 
   val logger: Logger = Logger(this.getClass)
+
   def approval2iReviewInfo(id: String): Future[RequestOutcome[ApprovalProcessReview]] = {
     def mockData(): ApprovalProcessReview = {
       ApprovalProcessReview(
         "oct9005",
         "Telling HMRC about extra income",
         LocalDate.of(2020, 5, 10),
-        List(PageReview("id1", "how-did-you-earn-extra-income", "NotStarted"),
+        List(
+          PageReview("id1", "how-did-you-earn-extra-income", "NotStarted"),
           PageReview("id2", "sold-goods-or-services/did-you-only-sell-personal-possessions", "NotStarted"),
           PageReview("id3", "sold-goods-or-services/have-you-made-a-profit-of-6000-or-more", "NotStarted"),
           PageReview("id4", "sold-goods-or-services/have-you-made-1000-or-more", "NotStarted"),
           PageReview("id5", "sold-goods-or-services/you-do-not-need-to-tell-hmrc", "NotStarted"),
           PageReview("id6", "rent-a-property/do-you-receive-any-income", "NotStarted"),
-          PageReview("id7", "rent-a-property/have-you-rented-out-a-room", "NotStarted")))
+          PageReview("id7", "rent-a-property/have-you-rented-out-a-room", "NotStarted")
+        )
+      )
     }
     Future(Right(mockData()))
   }

--- a/it/endpoints/GetApprovalProcessISpec.scala
+++ b/it/endpoints/GetApprovalProcessISpec.scala
@@ -34,7 +34,7 @@ class GetApprovalProcessISpec extends IntegrationSpec {
       (json \ "id").as[String]
     }
 
-    val processToSave: JsValue = ExamplePayloads.validApprovalProcessJson
+    val processToSave: JsValue = ExamplePayloads.simpleValidProcess
     lazy val id = populateDatabase(processToSave)
     lazy val request = buildRequest(s"/external-guidance/approval/$id")
     lazy val response: WSResponse = {

--- a/it/endpoints/PostApprovalProcessISpec.scala
+++ b/it/endpoints/PostApprovalProcessISpec.scala
@@ -27,7 +27,7 @@ class PostApprovalProcessISpec extends IntegrationSpec {
 
   "Calling the approval POST endpoint with a valid payload" should {
 
-    val processToSave: JsValue = ExamplePayloads.validApprovalProcessJson
+    val processToSave: JsValue = ExamplePayloads.simpleValidProcess
     val idToSave = (processToSave \ "meta" \ "id").as[String]
 
     lazy val request = buildRequest("/external-guidance/approval")

--- a/test/controllers/ProcessReviewControllerSpec.scala
+++ b/test/controllers/ProcessReviewControllerSpec.scala
@@ -179,5 +179,4 @@ class ProcessReviewControllerSpec extends WordSpec with Matchers with ScalaFutur
     }
   }
 
-
 }

--- a/test/mocks/MockApprovalRepository.scala
+++ b/test/mocks/MockApprovalRepository.scala
@@ -30,10 +30,10 @@ trait MockApprovalRepository extends MockFactory {
 
   object MockApprovalRepository {
 
-    def update(id: String, process: ApprovalProcess): CallHandler[Future[RequestOutcome[String]]] = {
+    def update(process: ApprovalProcess): CallHandler[Future[RequestOutcome[String]]] = {
       (mockApprovalRepository
-        .update(_: String, _: ApprovalProcess))
-        .expects(id, process)
+        .update(_: ApprovalProcess))
+        .expects(*)
     }
 
     def getById(id: String): CallHandler[Future[RequestOutcome[JsObject]]] = {

--- a/test/mocks/MockReviewService.scala
+++ b/test/mocks/MockReviewService.scala
@@ -27,6 +27,7 @@ trait MockReviewService extends MockFactory {
   val mockReviewService: ReviewService = mock[ReviewService]
 
   object MockReviewService {
+
     def approval2iReviewInfo(id: String): CallHandler[Future[RequestOutcome[ApprovalProcessReview]]] = {
       (mockReviewService
         .approval2iReviewInfo(_: String))

--- a/test/models/ApprovalProcessJson.scala
+++ b/test/models/ApprovalProcessJson.scala
@@ -43,7 +43,8 @@ trait ApprovalProcessJson {
       |    "lastModified" : {"$date": placeholder}
       |  },
       |  "process" : {
-      |  }
+      |  },
+      |  "version" : 1
       |}
     """.stripMargin.replaceAll("placeholder", submittedDateInMilliseconds.toString)
     )

--- a/test/models/ApprovalProcessJson.scala
+++ b/test/models/ApprovalProcessJson.scala
@@ -26,7 +26,8 @@ trait ApprovalProcessJson {
   val dateSubmitted: LocalDate = LocalDate.of(2020, 3, 3)
   val submittedDateInMilliseconds: Long = dateSubmitted.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
 
-  val approvalProcessMeta: ApprovalProcessMeta = ApprovalProcessMeta("oct90001", "This is the title", "SubmittedFor2iReview", dateSubmitted, dateSubmitted.atStartOfDay())
+  val approvalProcessMeta: ApprovalProcessMeta =
+    ApprovalProcessMeta("oct90001", "This is the title", "SubmittedFor2iReview", dateSubmitted, dateSubmitted.atStartOfDay())
   val approvalProcess: ApprovalProcess = ApprovalProcess(validId, approvalProcessMeta, Json.obj())
   val approvalProcessSummary: ApprovalProcessSummary = ApprovalProcessSummary("oct90001", "This is the title", dateSubmitted, "SubmittedFor2iReview")
 

--- a/test/models/ApprovalProcessJson.scala
+++ b/test/models/ApprovalProcessJson.scala
@@ -26,7 +26,7 @@ trait ApprovalProcessJson {
   val dateSubmitted: LocalDate = LocalDate.of(2020, 3, 3)
   val submittedDateInMilliseconds: Long = dateSubmitted.atStartOfDay(ZoneOffset.UTC).toInstant.toEpochMilli
 
-  val approvalProcessMeta: ApprovalProcessMeta = ApprovalProcessMeta("oct90001", "This is the title", "SubmittedFor2iReview", dateSubmitted)
+  val approvalProcessMeta: ApprovalProcessMeta = ApprovalProcessMeta("oct90001", "This is the title", "SubmittedFor2iReview", dateSubmitted, dateSubmitted.atStartOfDay())
   val approvalProcess: ApprovalProcess = ApprovalProcess(validId, approvalProcessMeta, Json.obj())
   val approvalProcessSummary: ApprovalProcessSummary = ApprovalProcessSummary("oct90001", "This is the title", dateSubmitted, "SubmittedFor2iReview")
 
@@ -39,12 +39,13 @@ trait ApprovalProcessJson {
       |    "id" : "oct90001",
       |    "title" : "This is the title",
       |    "status" : "SubmittedFor2iReview",
-      |    "dateSubmitted" : {"$date": placeholder}
+      |    "dateSubmitted" : {"$date": placeholder},
+      |    "lastModified" : {"$date": placeholder}
       |  },
       |  "process" : {
       |  }
       |}
-    """.stripMargin.replace("placeholder", submittedDateInMilliseconds.toString)
+    """.stripMargin.replaceAll("placeholder", submittedDateInMilliseconds.toString)
     )
     .as[JsObject]
 

--- a/test/models/ReviewProcessJson.scala
+++ b/test/models/ReviewProcessJson.scala
@@ -28,13 +28,16 @@ trait ReviewProcessJson {
     validId,
     "Telling HMRC about extra income",
     LocalDate.of(2020, 5, 10),
-    List(PageReview("id1", "how-did-you-earn-extra-income", "NotStarted"),
+    List(
+      PageReview("id1", "how-did-you-earn-extra-income", "NotStarted"),
       PageReview("id2", "sold-goods-or-services/did-you-only-sell-personal-possessions", "NotStarted"),
       PageReview("id3", "sold-goods-or-services/have-you-made-a-profit-of-6000-or-more", "NotStarted"),
       PageReview("id4", "sold-goods-or-services/have-you-made-1000-or-more", "NotStarted"),
       PageReview("id5", "sold-goods-or-services/you-do-not-need-to-tell-hmrc", "NotStarted"),
       PageReview("id6", "rent-a-property/do-you-receive-any-income", "NotStarted"),
-      PageReview("id7", "rent-a-property/have-you-rented-out-a-room", "NotStarted")))
+      PageReview("id7", "rent-a-property/have-you-rented-out-a-room", "NotStarted")
+    )
+  )
 
   val ReviewInfoJson: JsObject = Json.toJson(reviewInfo).as[JsObject]
 }

--- a/test/repositories/formatters/ApprovalProcessFormatterSpec.scala
+++ b/test/repositories/formatters/ApprovalProcessFormatterSpec.scala
@@ -19,6 +19,7 @@ package repositories.formatters
 import base.UnitSpec
 import models.{ApprovalProcess, ApprovalProcessJson}
 import play.api.libs.json.{JsError, JsSuccess, JsValue, Json}
+import repositories.formatters.ApprovalProcessFormatter.mongoFormat
 
 class ApprovalProcessFormatterSpec extends UnitSpec with ApprovalProcessJson {
 
@@ -28,7 +29,7 @@ class ApprovalProcessFormatterSpec extends UnitSpec with ApprovalProcessJson {
 
     "Result in a successful conversion for valid JSON" in {
 
-      validApprovalProcessJson.validate[ApprovalProcess](ApprovalProcessFormatter.mongoFormat) match {
+      validApprovalProcessJson.validate[ApprovalProcess] match {
         case JsSuccess(result, _) if result == approvalProcess => succeed
         case JsSuccess(_, _) => fail("Deserializing valid JSON did not create correct process")
         case _ => fail("Unable to parse valid Json")
@@ -37,7 +38,7 @@ class ApprovalProcessFormatterSpec extends UnitSpec with ApprovalProcessJson {
 
     "Result in a failure when for invalid JSON" in {
 
-      invalidJson.validate[ApprovalProcess](ApprovalProcessFormatter.mongoFormat) match {
+      invalidJson.validate[ApprovalProcess] match {
         case e: JsError => succeed
         case _ => fail("Invalid JSON payload should not have been successfully deserialized")
       }
@@ -48,7 +49,7 @@ class ApprovalProcessFormatterSpec extends UnitSpec with ApprovalProcessJson {
   "Serializing an approval process into JSON" should {
 
     "Generate the expected JSON" in {
-      val result: JsValue = Json.toJson(approvalProcess)(ApprovalProcessFormatter.mongoFormat)
+      val result: JsValue = Json.toJson(approvalProcess)
       result shouldBe validApprovalProcessJson.as[JsValue]
     }
   }


### PR DESCRIPTION
Updates to the end point to accept an ocelot process that gets turned into an ApprovalProcess with appropriate meta data.  
Added version to ApprovalProcess that can be used to identify when user requests access to an old version of the process. Version number is incremented when an updated process is submitted from ocelot