### PR TITLE
EG-595: Updates to save user details

### DIFF
--- a/app/models/PublishedProcess.scala
+++ b/app/models/PublishedProcess.scala
@@ -20,4 +20,4 @@ import java.time.LocalDateTime
 
 import play.api.libs.json.JsObject
 
-case class PublishedProcess(id: String, version: Int, datePublished: LocalDateTime, process: JsObject)
+case class PublishedProcess(id: String, version: Int, datePublished: LocalDateTime, process: JsObject, publishedBy: String)

--- a/app/repositories/formatters/PublishedProcessFormatter.scala
+++ b/app/repositories/formatters/PublishedProcessFormatter.scala
@@ -18,10 +18,12 @@ package repositories.formatters
 
 import java.time.LocalDateTime
 
-import models.PublishedProcess
+import models.{MongoDateTimeFormats, PublishedProcess}
 import play.api.libs.json._
 
 object PublishedProcessFormatter {
+
+  implicit val dateTimeFormat: Format[LocalDateTime] = MongoDateTimeFormats.localDateTimeFormats
 
   val read: JsValue => JsResult[PublishedProcess] = json =>
     for {
@@ -29,14 +31,16 @@ object PublishedProcessFormatter {
       version <- (json \ "version").validate[Int]
       datePublished <- (json \ "datePublished").validate[LocalDateTime]
       process <- (json \ "process").validate[JsObject]
-    } yield PublishedProcess(id, version, datePublished, process)
+      publishedBy <- (json \ "publishedBy").validate[String]
+    } yield PublishedProcess(id, version, datePublished, process, publishedBy)
 
   val write: PublishedProcess => JsObject = publishedProcess =>
     Json.obj(
       "_id" -> publishedProcess.id,
       "version" -> publishedProcess.version,
       "datePublished" -> publishedProcess.datePublished,
-      "process" -> publishedProcess.process
+      "process" -> publishedProcess.process,
+      "publishedBy" -> publishedProcess.publishedBy
     )
 
   implicit val mongoFormat: OFormat[PublishedProcess] = OFormat(read, write)

--- a/app/services/PublishedService.scala
+++ b/app/services/PublishedService.scala
@@ -49,10 +49,10 @@ class PublishedService @Inject() (repository: PublishedRepository) {
     }
   }
 
-  def save(id: String, jsonProcess: JsObject): Future[RequestOutcome[String]] = {
+  def save(id: String, user: String, jsonProcess: JsObject): Future[RequestOutcome[String]] = {
 
     def saveProcess: Future[RequestOutcome[String]] =
-      repository.save(id, jsonProcess) map {
+      repository.save(id, user, jsonProcess) map {
         case Left(_) =>
           logger.error(s"Request to publish $id has failed")
           Left(Errors(InternalServiceError))

--- a/app/services/ReviewService.scala
+++ b/app/services/ReviewService.scala
@@ -87,7 +87,7 @@ class ReviewService @Inject() (publishedService: PublishedService, repository: A
               case _ => publishIfRequired(approvalProcess)
             }
           case Left(errors) =>
-            logger.error(s"Could not change status of fact check review for process $id")
+            logger.error(s"Could not change status of 2i review for process $id")
             Future.successful(Left(errors))
         }
       case Left(errors) =>

--- a/app/testOnly/controllers/PublishedController.scala
+++ b/app/testOnly/controllers/PublishedController.scala
@@ -33,7 +33,7 @@ class PublishedController @Inject() (publishedRepo: PublishedRepository, testRep
 
   def post(): Action[JsValue] = Action.async(parse.json) { request =>
     def save(process: Process): Future[Result] = {
-      publishedRepo.save(process.meta.id, request.body.as[JsObject]).map {
+      publishedRepo.save(process.meta.id, "system", request.body.as[JsObject]).map {
         case Right(id) => Created(id)
         case Left(errors) => InternalServerError(Json.toJson(errors))
       }

--- a/test/controllers/PublishedControllerSpec.scala
+++ b/test/controllers/PublishedControllerSpec.scala
@@ -50,7 +50,7 @@ class PublishedControllerSpec extends UnitSpec with GuiceOneAppPerSuite with Pro
       trait ValidGetTest extends Test {
 
         val expectedProcess: JsObject = validOnePageJson.as[JsObject]
-        val returnedPublishedProcess: PublishedProcess = PublishedProcess(validId, 1, LocalDateTime.now(), validOnePageJson.as[JsObject])
+        val returnedPublishedProcess: PublishedProcess = PublishedProcess(validId, 1, LocalDateTime.now(), validOnePageJson.as[JsObject], "user")
 
         MockPublishedService
           .getById(validId)

--- a/test/mocks/MockApprovalProcessReviewRepository.scala
+++ b/test/mocks/MockApprovalProcessReviewRepository.scala
@@ -54,6 +54,18 @@ trait MockApprovalProcessReviewRepository extends MockFactory {
         .expects(id, version, pageUrl, reviewType, reviewInfo)
     }
 
+    def updateReview(id: String,
+                     version: Int,
+                     reviewType: String,
+                     updateUser: String,
+                     result: String
+                    ): CallHandler[Future[RequestOutcome[Unit]]] = {
+      (mockApprovalProcessReviewRepository
+        .updateReview(_: String, _: Int, _: String, _: String, _: String))
+        .expects(id, version, reviewType, updateUser, result)
+
+    }
+
   }
 
 }

--- a/test/mocks/MockPublishedRepository.scala
+++ b/test/mocks/MockPublishedRepository.scala
@@ -36,10 +36,10 @@ trait MockPublishedRepository extends MockFactory {
         .expects(id)
     }
 
-    def save(id: String, process: JsObject): CallHandler[Future[RequestOutcome[String]]] = {
+    def save(id: String, user: String, process: JsObject): CallHandler[Future[RequestOutcome[String]]] = {
       (mockPublishedRepository
-        .save(_: String, _: JsObject))
-        .expects(id, process)
+        .save(_: String, _: String, _: JsObject))
+        .expects(id, user, process)
     }
 
   }

--- a/test/mocks/MockPublishedService.scala
+++ b/test/mocks/MockPublishedService.scala
@@ -36,10 +36,10 @@ trait MockPublishedService extends MockFactory {
         .expects(id)
     }
 
-    def save(id: String, jsonProcess: JsObject): CallHandler[Future[RequestOutcome[String]]] = {
+    def save(id: String, user: String, jsonProcess: JsObject): CallHandler[Future[RequestOutcome[String]]] = {
       (mockPublishedService
-        .save(_: String, _: JsObject))
-        .expects(id, jsonProcess)
+        .save(_: String, _: String, _: JsObject))
+        .expects(id, user, jsonProcess)
     }
   }
 

--- a/test/repositories/formatters/PublishedProcessFormatterSpec.scala
+++ b/test/repositories/formatters/PublishedProcessFormatterSpec.scala
@@ -16,7 +16,7 @@
 
 package repositories.formatters
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneId}
 
 import base.UnitSpec
 import models.PublishedProcess
@@ -29,16 +29,16 @@ class PublishedProcessFormatterSpec extends UnitSpec {
   private val id: String = "ext90002"
 
   private val datePublished = LocalDateTime.of(2020, 1, 1, 12, 0, 1)
-
-  private val publishedProcess: PublishedProcess = PublishedProcess(id, 1, datePublished, process)
+  private val publishedProcess: PublishedProcess = PublishedProcess(id, 1, datePublished, process, "user")
 
   private val json = Json.parse(
     s"""
        |{
        | "_id": "$id",
        | "version": 1,
-       | "datePublished": "2020-01-01T12:00:01",
-       | "process": {}
+       | "datePublished": {"$$date": ${datePublished.atZone(ZoneId.of("UTC")).toInstant.toEpochMilli}},
+       | "process": {},
+       | "publishedBy": "user"
        |}
        |""".stripMargin
   )

--- a/test/services/PublishedServiceSpec.scala
+++ b/test/services/PublishedServiceSpec.scala
@@ -34,7 +34,7 @@ class PublishedServiceSpec extends UnitSpec {
     val validId: String = "ext90005"
     val invalidId: String = "ext9005"
     val invalidProcess: JsObject = Json.obj("idx" -> invalidId)
-    val publishedProcess: PublishedProcess = PublishedProcess(validId, 1, LocalDateTime.now(), validOnePageJson.as[JsObject])
+    val publishedProcess: PublishedProcess = PublishedProcess(validId, 1, LocalDateTime.now(), validOnePageJson.as[JsObject], "user")
 
     lazy val target: PublishedService = new PublishedService(mockPublishedRepository)
   }
@@ -100,10 +100,10 @@ class PublishedServiceSpec extends UnitSpec {
         val expected: RequestOutcome[String] = Right(validId)
 
         MockPublishedRepository
-          .save(validId, validOnePageJson.as[JsObject])
+          .save(validId, "userId", validOnePageJson.as[JsObject])
           .returns(Future.successful(expected))
 
-        whenReady(target.save(validId, validOnePageJson.as[JsObject])) {
+        whenReady(target.save(validId, "userId", validOnePageJson.as[JsObject])) {
           case Right(id) => id shouldBe validId
           case _ => fail
         }
@@ -115,16 +115,16 @@ class PublishedServiceSpec extends UnitSpec {
       "not call the repository" in new Test {
 
         MockPublishedRepository
-          .save(validId, validOnePageJson.as[JsObject])
+          .save(validId, "userId", validOnePageJson.as[JsObject])
           .never()
 
-        target.save(validId, invalidProcess)
+        target.save(validId, "userId", invalidProcess)
       }
 
       "return a bad request error" in new Test {
         val expected: RequestOutcome[String] = Left(Errors(BadRequestError))
 
-        whenReady(target.save(validId, invalidProcess)) {
+        whenReady(target.save(validId, "userId", invalidProcess)) {
           case result @ Left(_) => result shouldBe expected
           case _ => fail
         }
@@ -137,10 +137,10 @@ class PublishedServiceSpec extends UnitSpec {
         val expected: RequestOutcome[String] = Left(Errors(InternalServiceError))
 
         MockPublishedRepository
-          .save(validId, validOnePageJson.as[JsObject])
+          .save(validId, "userId", validOnePageJson.as[JsObject])
           .returns(Future.successful(repositoryResponse))
 
-        whenReady(target.save(validId, validOnePageJson.as[JsObject])) {
+        whenReady(target.save(validId, "userId", validOnePageJson.as[JsObject])) {
           case result @ Left(_) => result shouldBe expected
           case _ => fail
         }

--- a/test/services/ReviewServiceSpec.scala
+++ b/test/services/ReviewServiceSpec.scala
@@ -197,11 +197,10 @@ class ReviewServiceSpec extends UnitSpec with MockFactory with ReviewData with A
 
           MockApprovalProcessReviewRepository
             .updateReview("validId", approvalProcess.version, ReviewType2i, statusChange2iReviewInfo.userId, statusChange2iReviewInfo.status)
-            .returns(Future.successful(Right(())))
+            .never()
 
           MockApprovalRepository
             .changeStatus("validId", StatusPublished, "userId")
-            .returns(Future.successful(expected))
             .never()
 
           whenReady(service.twoEyeReviewComplete("validId", statusChange2iReviewInfo)) { result =>
@@ -235,7 +234,7 @@ class ReviewServiceSpec extends UnitSpec with MockFactory with ReviewData with A
       "the updateReview fails to update the details" should {
         "return a not found response" in new Test {
 
-          val expected: RequestOutcome[Unit] = Left(Errors(NotFoundError))
+          val expected: RequestOutcome[Unit] = Left(Errors(DatabaseError))
 
           MockApprovalRepository
             .getById("validId")
@@ -340,7 +339,9 @@ class ReviewServiceSpec extends UnitSpec with MockFactory with ReviewData with A
         1,
         ReviewType2i,
         "This is the title",
-        List(ApprovalProcessPageReview("1", "/pageUrl", Some("result1")), ApprovalProcessPageReview("2", "/pageUrl2", Some("NotStarted"), updateDate = currentDateTime))
+        List(
+          ApprovalProcessPageReview("1", "/pageUrl", Some("result1")),
+          ApprovalProcessPageReview("2", "/pageUrl2", Some("NotStarted"), updateDate = currentDateTime))
       )
 
     }
@@ -615,6 +616,11 @@ class ReviewServiceSpec extends UnitSpec with MockFactory with ReviewData with A
             .getById("validId")
             .returns(Future.successful(Left(Errors(NotFoundError))))
 
+          MockApprovalProcessReviewRepository
+            .updateReview("validId", approvalProcess.version, ReviewTypeFactCheck, statusChange2iReviewInfo.userId, statusChange2iReviewInfo.status)
+            .returns(Future.successful(Right(())))
+            .never()
+
           MockApprovalRepository
             .changeStatus("validId", StatusPublished, "userId")
             .returns(Future.successful(expected))
@@ -651,6 +657,11 @@ class ReviewServiceSpec extends UnitSpec with MockFactory with ReviewData with A
           MockApprovalProcessReviewRepository
             .updateReview("validId", factCheckProcess.version, ReviewTypeFactCheck, statusChange2iReviewInfo.userId, statusChange2iReviewInfo.status)
             .returns(Future.successful(Left(Errors(NotFoundError))))
+
+          MockApprovalRepository
+            .changeStatus("validId", StatusPublished, "userId")
+            .returns(Future.successful(expected))
+            .never()
 
           whenReady(service.factCheckComplete("validId", statusChange2iReviewInfo)) { result =>
             result shouldBe expected


### PR DESCRIPTION
Storing user id when page reviewed, review complete and process published