### PR TITLE
Dl 10393

### DIFF
--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -37,3 +37,4 @@ class Module extends AbstractModule {
     bind(classOf[TodayProvider]).to(classOf[DefaultTodayProvider])
   }
 }
+

--- a/app/controllers/ApprovalController.scala
+++ b/app/controllers/ApprovalController.scala
@@ -17,25 +17,26 @@
 package controllers
 
 import controllers.actions.AllRolesAction
+
 import javax.inject.{Inject, Singleton}
 import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, ControllerComponents, Result}
-import services.{TimescalesService, ApprovalService}
+import services.{ApprovalService, TimescalesService}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import models.Constants._
 import core.models.errors.{BadRequestError, DuplicateKeyError, Error}
 import core.models.errors.{NotFoundError, ValidationError, InternalServerError => ServerError}
-import models.errors.{OcelotError, DuplicateProcessCodeError}
+import models.errors.{DuplicateProcessCodeError, OcelotError}
 import play.api.libs.json.Json.toJson
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ApprovalController @Inject() (allRolesAction: AllRolesAction,
                                     approvalService: ApprovalService,
                                     timescalesService: TimescalesService,
-                                    cc: ControllerComponents) extends BackendController(cc) {
+                                    cc: ControllerComponents)(implicit ec: ExecutionContext) extends BackendController(cc) {
 
   val logger: Logger = Logger(getClass)
 

--- a/app/controllers/ArchivedController.scala
+++ b/app/controllers/ArchivedController.scala
@@ -18,19 +18,21 @@ package controllers
 
 import controllers.actions.AllRolesAction
 import models.errors.OcelotError
+
 import javax.inject.{Inject, Singleton}
 import core.models.errors.{BadRequestError, NotFoundError, InternalServerError => ServerError}
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.ArchiveService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import scala.concurrent.ExecutionContext.Implicits.global
 import play.api.libs.json._
+
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class ArchivedController @Inject() (archivedService: ArchiveService,
                                     cc: ControllerComponents,
-                                    identify: AllRolesAction) extends BackendController(cc) {
+                                    identify: AllRolesAction)(implicit ec: ExecutionContext) extends BackendController(cc) {
   import Json._
 
   def get(id: String): Action[AnyContent] = Action.async {

--- a/app/controllers/ProcessReviewController.scala
+++ b/app/controllers/ProcessReviewController.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import controllers.actions.{FactCheckerAction, TwoEyeReviewerAction}
+
 import javax.inject.{Inject, Singleton}
 import core.models.errors.{InternalServerError => ServerError, _}
 import models.errors.OcelotError
@@ -27,8 +28,8 @@ import services.ReviewService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import models.Constants._
 import play.api.Logger
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ProcessReviewController @Inject() (
@@ -36,7 +37,7 @@ class ProcessReviewController @Inject() (
   twoEyeReviewerAction: TwoEyeReviewerAction,
   reviewService: ReviewService,
   cc: ControllerComponents
-) extends BackendController(cc) {
+)(implicit ec: ExecutionContext) extends BackendController(cc) {
 
   val logger: Logger = Logger(getClass())
 

--- a/app/controllers/PublishedController.scala
+++ b/app/controllers/PublishedController.scala
@@ -18,21 +18,22 @@ package controllers
 
 import controllers.actions.AllRolesAction
 import models.errors.OcelotError
+
 import javax.inject.{Inject, Singleton}
 import core.models.errors.{BadRequestError, NotFoundError, InternalServerError => ServerError}
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
-import services.{TimescalesService, PublishedService}
+import services.{PublishedService, TimescalesService}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.concurrent.{ExecutionContext, Future}
 import play.api.libs.json._
 
 @Singleton
 class PublishedController @Inject() (publishedService: PublishedService,
                                      timescalesService: TimescalesService,
                                      cc: ControllerComponents,
-                                     identify: AllRolesAction) extends BackendController(cc) {
+                                     identify: AllRolesAction)(implicit ec: ExecutionContext) extends BackendController(cc) {
   import Json._
   import models.PublishedProcess.Implicits._
 

--- a/app/controllers/ScratchController.scala
+++ b/app/controllers/ScratchController.scala
@@ -17,20 +17,20 @@
 package controllers
 
 import javax.inject.{Inject, Singleton}
-import core.models.errors.{BadRequestError, ValidationError, Error, InternalServerError => ServerError, NotFoundError}
+import core.models.errors.{BadRequestError, Error, NotFoundError, ValidationError, InternalServerError => ServerError}
 import models.errors.OcelotError
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
-import services.{TimescalesService, ScratchService}
+import services.{ScratchService, TimescalesService}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import play.api.Logger
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton()
 class ScratchController @Inject() (scratchService: ScratchService,
                                    timescalesService: TimescalesService,
-                                   cc: ControllerComponents) extends BackendController(cc) {
+                                   cc: ControllerComponents)(implicit ec: ExecutionContext) extends BackendController(cc) {
+
   val logger: Logger = Logger(getClass)
   import Json._
 

--- a/app/controllers/TimescalesController.scala
+++ b/app/controllers/TimescalesController.scala
@@ -21,12 +21,12 @@ import core.models.errors.{ValidationError, InternalServerError => ServerError}
 import models.errors.OcelotError
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
-import services.{PublishedService, ApprovalService, TimescalesService}
+import services.{ApprovalService, PublishedService, TimescalesService}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import play.api.Logger
 import controllers.actions.AllRolesAction
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 import models.requests.IdentifierRequest
 
 @Singleton()
@@ -34,7 +34,7 @@ class TimescalesController @Inject() (timescaleService: TimescalesService,
                                       publishService: PublishedService,
                                       approvalService: ApprovalService,
                                       cc: ControllerComponents,
-                                      allRolesAction: AllRolesAction) extends BackendController(cc) {
+                                      allRolesAction: AllRolesAction)(implicit ec: ExecutionContext) extends BackendController(cc) {
 
   val logger: Logger = Logger(getClass)
 

--- a/app/core/models/ocelot/errors/GuidanceErrors.scala
+++ b/app/core/models/ocelot/errors/GuidanceErrors.scala
@@ -61,7 +61,6 @@ case class UseOfReservedUrl(id: String) extends FlowError
 case class PageOccursInMultiplSequenceFlows(id: String) extends FlowError
 case class MultipleExclusiveOptions(id: String) extends FlowError
 case class ErrorRedirectToFirstNonPageStanzaOnly(id: String) extends FlowError
-case class MissingUniqueFlowTerminator(id: String) extends FlowError
 case class InvalidLabelName(id: String) extends FlowError
 case class InvalidFieldWidth(id: String) extends FlowError
 case class MissingTimescaleDefinition(timescaleId: String) extends TimescalesError

--- a/app/core/models/ocelot/errors/GuidanceErrors.scala
+++ b/app/core/models/ocelot/errors/GuidanceErrors.scala
@@ -67,6 +67,7 @@ case class InvalidFieldWidth(id: String) extends FlowError
 case class MissingTimescaleDefinition(timescaleId: String) extends TimescalesError
 case class IncompleteInputPage(id: String) extends FlowError
 case class MissingTitle(id: String) extends FlowError
+case class AllFlowsMustContainMultiplePages(id: String) extends FlowError
 
 object GuidanceError {
 

--- a/app/models/errors/package.scala
+++ b/app/models/errors/package.scala
@@ -52,6 +52,8 @@ package object errors {
                     "Page redisplay after a ValueError must link to the first stanza after the PageStanza", e.id)
     case e: MissingUniqueFlowTerminator =>
       ErrorReport(s"MissingUniqueFlowTerminator: Flow doesn't have a unique termination page ${e.id}, possible main flow connection into a sequence flow",e.id)
+    case e: AllFlowsMustContainMultiplePages =>
+      ErrorReport(s"AllFlowsMustContainMultiplePages: Page ${e.id} is reused in a flow, flows containing reused pages must contain more than one page", e.id)
     case e: InvalidLabelName =>
       ErrorReport(s"InvalidLabelName: Invalid label name in stanza ${e.id}", e.id)
     case e: InvalidFieldWidth =>

--- a/app/models/errors/package.scala
+++ b/app/models/errors/package.scala
@@ -50,8 +50,6 @@ package object errors {
     case e: ErrorRedirectToFirstNonPageStanzaOnly =>
       ErrorReport(s"ErrorRedirectToFirstNonPageStanzaOnly: Invalid link to stanza ${e.id}. " +
                     "Page redisplay after a ValueError must link to the first stanza after the PageStanza", e.id)
-    case e: MissingUniqueFlowTerminator =>
-      ErrorReport(s"MissingUniqueFlowTerminator: Flow doesn't have a unique termination page ${e.id}, possible main flow connection into a sequence flow",e.id)
     case e: AllFlowsMustContainMultiplePages =>
       ErrorReport(s"AllFlowsMustContainMultiplePages: Page ${e.id} is reused in a flow, flows containing reused pages must contain more than one page", e.id)
     case e: InvalidLabelName =>

--- a/app/repositories/ApprovalProcessReviewRepository.scala
+++ b/app/repositories/ApprovalProcessReviewRepository.scala
@@ -18,7 +18,6 @@ package repositories
 
 import java.time.ZonedDateTime
 import java.util.UUID
-
 import javax.inject.{Inject, Singleton}
 import core.models.errors.{DatabaseError, NotFoundError}
 import core.models.RequestOutcome
@@ -32,8 +31,7 @@ import org.mongodb.scala.model.Updates._
 import org.mongodb.scala.model._
 import uk.gov.hmrc.mongo._
 import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import org.mongodb.scala.result.InsertOneResult
 import org.mongodb.scala.bson.conversions.Bson
 
@@ -45,7 +43,7 @@ trait ApprovalProcessReviewRepository {
 }
 
 @Singleton
-class ApprovalProcessReviewRepositoryImpl @Inject() (implicit mongo: MongoComponent)
+class ApprovalProcessReviewRepositoryImpl @Inject() (implicit mongo: MongoComponent, ec: ExecutionContext)
     extends PlayMongoRepository[ApprovalProcessReview](
       mongoComponent = mongo,
       collectionName = "approvalProcessReviews",

--- a/app/repositories/ScratchRepository.scala
+++ b/app/repositories/ScratchRepository.scala
@@ -24,8 +24,7 @@ import core.models.RequestOutcome
 import models.ScratchProcess
 import play.api.libs.json.JsObject
 import config.AppConfig
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import play.api.Logger
 import java.util.concurrent.TimeUnit
 import org.mongodb.scala._
@@ -43,7 +42,7 @@ trait ScratchRepository {
 }
 
 @Singleton
-class ScratchRepositoryImpl @Inject() (component: MongoComponent, appConfig: AppConfig)
+class ScratchRepositoryImpl @Inject() (component: MongoComponent, appConfig: AppConfig)(implicit ec: ExecutionContext)
     extends PlayMongoRepository[ScratchProcess](
       collectionName = "scratchProcesses",
       mongoComponent = component,

--- a/app/repositories/TimescalesRepository.scala
+++ b/app/repositories/TimescalesRepository.scala
@@ -23,10 +23,9 @@ import core.models.RequestOutcome
 import play.api.libs.json.JsValue
 import play.api.Logger
 import config.AppConfig
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import models.TimescalesUpdate
 
+import scala.concurrent.{ExecutionContext, Future}
+import models.TimescalesUpdate
 import org.mongodb.scala._
 import org.mongodb.scala.model.Filters._
 import org.mongodb.scala.model.Updates._
@@ -44,7 +43,7 @@ trait TimescalesRepository {
 }
 
 @Singleton
-class TimescalesRepositoryImpl @Inject() (component: MongoComponent, appConfig: AppConfig)
+class TimescalesRepositoryImpl @Inject() (component: MongoComponent, appConfig: AppConfig)(implicit ec: ExecutionContext)
     extends PlayMongoRepository[TimescalesUpdate](
       collectionName = "timescales",
       mongoComponent = component,

--- a/app/services/ApprovalService.scala
+++ b/app/services/ApprovalService.scala
@@ -17,8 +17,8 @@
 package services
 
 import java.util.UUID
-
 import config.AppConfig
+
 import javax.inject.{Inject, Singleton}
 import models._
 import core.models._
@@ -27,8 +27,8 @@ import core.services.fromPageDetails
 import play.api.Logger
 import play.api.libs.json._
 import repositories.{ApprovalProcessReviewRepository, ApprovalRepository, PublishedRepository}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 import play.api.libs.json.{Json, OFormat}
 
 @Singleton
@@ -37,9 +37,8 @@ class ApprovalService @Inject() (
     reviewRepository: ApprovalProcessReviewRepository,
     publishedRepository: PublishedRepository,
     pageBuilder: ValidatingPageBuilder,
-    timescalesService: TimescalesService,
-    implicit val appConfig: AppConfig
-) {
+    timescalesService: TimescalesService
+)(implicit ec: ExecutionContext, val appConfig: AppConfig) {
 
   val logger: Logger = Logger(this.getClass)
 

--- a/app/services/ArchiveService.scala
+++ b/app/services/ArchiveService.scala
@@ -19,16 +19,16 @@ package services
 import javax.inject.{Inject, Singleton}
 import core.models.errors.{BadRequestError, InternalServerError, NotFoundError}
 import core.models.RequestOutcome
-import models.{ProcessSummary, ArchivedProcess}
+import models.{ArchivedProcess, ProcessSummary}
 import play.api.Logger
 import repositories.ArchiveRepository
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import play.api.libs.json.{Json, OFormat, JsValue}
+
+import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.json.{JsValue, Json, OFormat}
 import core.services.isTimeValueInMilliseconds
 
 @Singleton
-class ArchiveService @Inject() (archive: ArchiveRepository) {
+class ArchiveService @Inject() (archive: ArchiveRepository)(implicit ec: ExecutionContext) {
 
   val logger: Logger = Logger(this.getClass)
 

--- a/app/services/PublishedService.scala
+++ b/app/services/PublishedService.scala
@@ -25,14 +25,14 @@ import play.api.Logger
 import play.api.libs.json.JsObject
 import repositories.{ApprovalRepository, ArchiveRepository, PublishedRepository}
 import core.services.validateProcessId
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import play.api.libs.json.{Json, OFormat, JsValue}
+
+import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.json.{JsValue, Json, OFormat}
 
 @Singleton
 class PublishedService @Inject() (published: PublishedRepository,
                                   archive: ArchiveRepository,
-                                  approval: ApprovalRepository) {
+                                  approval: ApprovalRepository)(implicit ec: ExecutionContext) {
 
   val logger: Logger = Logger(this.getClass)
 

--- a/app/services/ReviewService.scala
+++ b/app/services/ReviewService.scala
@@ -24,11 +24,12 @@ import core.models.errors._
 import core.models.ocelot.Process
 import play.api.Logger
 import repositories.{ApprovalProcessReviewRepository, ApprovalRepository}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class ReviewService @Inject() (publishedService: PublishedService, repository: ApprovalRepository, reviewRepository: ApprovalProcessReviewRepository) {
+class ReviewService @Inject() (publishedService: PublishedService, repository: ApprovalRepository, reviewRepository: ApprovalProcessReviewRepository)
+                              (implicit ec: ExecutionContext) {
 
   val logger: Logger = Logger(this.getClass)
 

--- a/app/services/ScratchService.scala
+++ b/app/services/ScratchService.scala
@@ -17,6 +17,7 @@
 package services
 
 import core.services._
+
 import java.util.UUID
 import javax.inject.{Inject, Singleton}
 import core.models.RequestOutcome
@@ -25,15 +26,15 @@ import core.models.errors.{BadRequestError, InternalServerError, NotFoundError}
 import play.api.libs.json.JsObject
 import repositories.ScratchRepository
 import play.api.Logger
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 import config.AppConfig
 
 @Singleton
 class ScratchService @Inject() (repository: ScratchRepository,
                                 pageBuilder: ValidatingPageBuilder,
-                                timescalesService: TimescalesService,
-                                implicit val c: AppConfig) {
+                                timescalesService: TimescalesService)
+                               (implicit ec: ExecutionContext, val c: AppConfig) {
   val logger: Logger = Logger(getClass)
 
   def save(json: JsObject): Future[RequestOutcome[UUID]] =

--- a/app/services/TimescalesService.scala
+++ b/app/services/TimescalesService.scala
@@ -19,20 +19,21 @@ package services
 import javax.inject.{Inject, Singleton}
 import core.models.RequestOutcome
 import core.models.ocelot.Process
-import core.models.errors.{ValidationError, InternalServerError, NotFoundError}
-import play.api.libs.json.{Json, JsValue, JsObject}
+import core.models.errors.{InternalServerError, NotFoundError, ValidationError}
+import play.api.libs.json.{JsObject, JsValue, Json}
 import repositories.TimescalesRepository
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 import config.AppConfig
 import play.api.Logger
+
 import java.time.ZonedDateTime
-import models.{UpdateDetails, TimescalesResponse}
+import models.{TimescalesResponse, UpdateDetails}
 
 @Singleton
 class TimescalesService @Inject() (
     repository: TimescalesRepository,
-    appConfig: AppConfig) {
+    appConfig: AppConfig)(implicit ec: ExecutionContext) {
 
   val logger: Logger = Logger(getClass)
 

--- a/app/services/ValidatingPageBuilder.scala
+++ b/app/services/ValidatingPageBuilder.scala
@@ -216,8 +216,7 @@ class ValidatingPageBuilder @Inject() (val pageBuilder: PageBuilder){
         checkExclusiveSequenceTypeError(xs, errors)
     }
 
-  private def checkForMinimumTwoPageFlows(vertices: List[PageVertex], vertexMap: Map[String, PageVertex])
-                                         (implicit stanzaMap: Map[String, Stanza]): List[AllFlowsMustContainMultiplePages] = {
+  private def checkForMinimumTwoPageFlows(vertices: List[PageVertex], vertexMap: Map[String, PageVertex]): List[AllFlowsMustContainMultiplePages] = {
 
     val flowPageVertices: List[PageVertex] = for {
       pv <- vertices.filterNot(_.flows.isEmpty)                   // Sequences

--- a/app/services/ValidatingPageBuilder.scala
+++ b/app/services/ValidatingPageBuilder.scala
@@ -305,4 +305,16 @@ class ValidatingPageBuilder @Inject() (val pageBuilder: PageBuilder){
       case x +: _ if keyedStanzas(x).visual => List(VisualStanzasAfterDataInput(x))
       case x +: xs => checkDataInputFollowers(keyedStanzas(x).next ++ xs, keyedStanzas, leadingStanzaIds, x :: seen)
     }
+
+  private def checkForMinimumTwoPageFlows(vertices: List[PageVertex], vertexMap: Map[String, PageVertex]): List[GuidanceError] = {
+
+    val flowPageVertices: List[PageVertex] = for {
+      pv <- vertices.filterNot(_.flows.isEmpty)
+      flw <- pv.flows
+    } yield vertexMap(flw)
+
+    flowPageVertices.filter(_.next.contains("end")).map(x => AllFlowsMustContainMultiplePages(x.id))
+
+  }
+
 }

--- a/app/services/ValidatingPageBuilder.scala
+++ b/app/services/ValidatingPageBuilder.scala
@@ -88,18 +88,38 @@ class ValidatingPageBuilder @Inject() (val pageBuilder: PageBuilder){
         println(s"\n****\nAllFlowsMustContainMultiplePages errors found:\n$errors\n****\n")
         val reuse = checkForSequencePageReuse(vertices, vertexMap, mainFlow)
         val uniqueTerminator = checkAllFlowsHaveUniqueTerminationPage(vertices, vertexMap, mainFlow)
-        reuse ++
-        uniqueTerminator match {
+        reuse ++ uniqueTerminator match {
           case Nil =>
             println(s"\n****\nNo Existing sequence errors found\n****\n")
             Nil
           case _ =>
             val seqErrors = reuse.filter(e => errors.exists(x => x.id == e.id)) ++ uniqueTerminator.filter(e => errors.exists(x => x.id == e.id))
             println(s"\n****\nerrors found:\n${errors ++ seqErrors}\n****\n")
-//            twoPageErrors ++ seqErrors
-            errors ++ seqErrors
+            errors.filter(e => reuse.exists(x => x.id ==e.id) || uniqueTerminator.exists(x => x.id ==e.id)) ++ seqErrors
         }
     }
+
+//  private def checkSequenceErrors(vertices: List[PageVertex], vertexMap: Map[String, PageVertex], mainFlow: List[String])
+//                                 (implicit stanzaMap: Map[String, Stanza]): List[GuidanceError] =
+//    checkForMinimumTwoPageFlows(vertices, vertexMap) match {
+//      case Nil =>
+//        println(s"\n****\nNo AllFlowsMustContainMultiplePages errors found\n****\n")
+//        Nil
+//      case errors =>
+//        println(s"\n****\nAllFlowsMustContainMultiplePages errors found:\n$errors\n****\n")
+//        val reuse = checkForSequencePageReuse(vertices, vertexMap, mainFlow)
+//        val uniqueTerminator = checkAllFlowsHaveUniqueTerminationPage(vertices, vertexMap, mainFlow)
+//        reuse ++ uniqueTerminator match {
+//          case Nil =>
+//            println(s"\n****\nNo Existing sequence errors found\n****\n")
+//            Nil
+//          case seqErrors =>
+//            //            val seqErrors = reuse.filter(e => errors.exists(x => x.id == e.id)) ++ uniqueTerminator//.filter(e => errors.exists(x => x.id == e.id))
+//            println(s"\n****\nerrors found:\n${errors ++ seqErrors}\n****\n")
+//            //            twoPageErrors ++ seqErrors
+//            errors ++ seqErrors
+//        }
+//    }
 
   @tailrec
   private def confirmInputPageErrorCallouts(pages: Seq[Page], errors: List[GuidanceError]): List[GuidanceError] = {

--- a/app/testOnly/controllers/ApprovalController.scala
+++ b/app/testOnly/controllers/ApprovalController.scala
@@ -16,30 +16,26 @@
 
 package testOnly.controllers
 
-import javax.inject.{Inject, Singleton}
-import core.models.errors.{BadRequestError, DuplicateKeyError, Error}
-import core.models.errors.{ValidationError, InternalServerError => ServerError}
-import models.errors.{OcelotError, DuplicateProcessCodeError}
-import play.api.libs.json._
-import play.api.mvc.{Action, AnyContent, ControllerComponents}
-import testOnly.repositories.{ApprovalProcessReviewRepository, ApprovalRepository}
-import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import models.errors.OcelotError
 import core.models._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import core.models.errors.{BadRequestError, DuplicateKeyError, Error, ValidationError, InternalServerError => ServerError}
 import models.Constants._
+import models.errors.{DuplicateProcessCodeError, OcelotError}
+import play.api.Logger
+import play.api.libs.json.Json.toJson
 import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, ControllerComponents, Result}
 import services.ApprovalService
-import play.api.Logger
-import play.api.libs.json.Json.toJson
+import testOnly.repositories.{ApprovalProcessReviewRepository, ApprovalRepository}
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ApprovalController @Inject() (approvalService: ApprovalService,
                                     testRepo: ApprovalRepository,
                                     testReviewRepo: ApprovalProcessReviewRepository,
-                                    cc: ControllerComponents) extends BackendController(cc) {
+                                    cc: ControllerComponents)(implicit ec: ExecutionContext) extends BackendController(cc) {
 
   val logger: Logger = Logger(getClass)
 

--- a/app/testOnly/controllers/PublishedController.scala
+++ b/app/testOnly/controllers/PublishedController.scala
@@ -24,11 +24,11 @@ import play.api.mvc.{Action, AnyContent, ControllerComponents, Result}
 import repositories.PublishedRepository
 import testOnly.repositories.{PublishedRepository => TestPublishedRepository}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class PublishedController @Inject() (publishedRepo: PublishedRepository, testRepo: TestPublishedRepository, cc: ControllerComponents)
+class PublishedController @Inject() (publishedRepo: PublishedRepository, testRepo: TestPublishedRepository, cc: ControllerComponents)(implicit ec: ExecutionContext)
     extends BackendController(cc) {
 
   def post(): Action[JsValue] = Action.async(parse.json) { request =>

--- a/app/testOnly/controllers/ScratchController.scala
+++ b/app/testOnly/controllers/ScratchController.scala
@@ -23,10 +23,11 @@ import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import testOnly.repositories.ScratchRepository
-import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.concurrent.ExecutionContext
 
 @Singleton
-class ScratchController @Inject() (testRepo: ScratchRepository, cc: ControllerComponents) extends BackendController(cc) {
+class ScratchController @Inject() (testRepo: ScratchRepository, cc: ControllerComponents)(implicit ec: ExecutionContext) extends BackendController(cc) {
 
   def delete(id: String): Action[AnyContent] = Action.async {
     testRepo.delete(id).map {

--- a/app/testOnly/repositories/ApprovalProcessReviewRepository.scala
+++ b/app/testOnly/repositories/ApprovalProcessReviewRepository.scala
@@ -22,15 +22,14 @@ import core.models.RequestOutcome
 import models.ApprovalProcessReview
 import play.api.Logger
 import org.mongodb.scala._
-
 import org.mongodb.scala.model.Filters._
 import uk.gov.hmrc.mongo._
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class ApprovalProcessReviewRepository @Inject() (implicit component: MongoComponent)
+class ApprovalProcessReviewRepository @Inject() (implicit component: MongoComponent, ec: ExecutionContext)
     extends PlayMongoRepository[ApprovalProcessReview](
       collectionName = "approvalProcessReviews",
       mongoComponent = component,

--- a/app/testOnly/repositories/ApprovalRepository.scala
+++ b/app/testOnly/repositories/ApprovalRepository.scala
@@ -21,16 +21,15 @@ import core.models.errors.DatabaseError
 import core.models.RequestOutcome
 import models.ApprovalProcess
 import play.api.Logger
-import models.ApprovalProcess
 import org.mongodb.scala._
 import org.mongodb.scala.model.Filters._
 import uk.gov.hmrc.mongo._
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class ApprovalRepository @Inject() (component: MongoComponent)
+class ApprovalRepository @Inject() (component: MongoComponent)(implicit ec: ExecutionContext)
     extends PlayMongoRepository[ApprovalProcess](
       collectionName = "approvalProcesses",
       mongoComponent = component,

--- a/app/testOnly/repositories/PublishedRepository.scala
+++ b/app/testOnly/repositories/PublishedRepository.scala
@@ -25,11 +25,11 @@ import org.mongodb.scala._
 import org.mongodb.scala.model.Filters._
 import uk.gov.hmrc.mongo._
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class PublishedRepository @Inject() (component: MongoComponent)
+class PublishedRepository @Inject() (component: MongoComponent)(implicit ec: ExecutionContext)
     extends PlayMongoRepository[PublishedProcess](
       collectionName = "publishedProcesses",
       mongoComponent = component,

--- a/app/testOnly/repositories/ScratchRepository.scala
+++ b/app/testOnly/repositories/ScratchRepository.scala
@@ -25,11 +25,11 @@ import org.mongodb.scala._
 import org.mongodb.scala.model.Filters._
 import uk.gov.hmrc.mongo._
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class ScratchRepository @Inject() (component: MongoComponent)
+class ScratchRepository @Inject() (component: MongoComponent)(implicit ec: ExecutionContext)
   extends PlayMongoRepository[ScratchProcess](
     collectionName = "scratchProcesses",
     mongoComponent = component,

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ import uk.gov.hmrc.DefaultBuildSettings.integrationTestSettings
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 
 val appName = "external-guidance"
-val silencerVersion = "1.7.12"
+val silencerVersion = "1.17.13"
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,6 @@
  */
 
 import uk.gov.hmrc.DefaultBuildSettings.integrationTestSettings
-import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 
 val appName = "external-guidance"
 val silencerVersion = "1.17.13"
@@ -29,7 +28,6 @@ lazy val microservice = Project(appName, file("."))
     scalacOptions ++= Seq("-feature"),
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test
   )
-  .settings(publishingSettings: _*)
   .configs(IntegrationTest)
   .settings(CodeCoverageSettings.settings: _*)
   .settings(integrationTestSettings(): _*)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -21,12 +21,6 @@ include "seed-timescales.conf"
 
 appName = external-guidance
 
-# An ApplicationLoader that uses Guice to bootstrap the application.
-play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
-
-# Primary entry point for all HTTP requests on Play applications
-play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
-
 # Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
 # An audit connector must be provided.
 play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
@@ -102,37 +96,15 @@ controllers {
 
 
 # Metrics plugin settings - graphite reporting is configured on a per env basis
-metrics {
-  name = ${appName}
-  rateUnit = SECONDS
-  durationUnit = SECONDS
-  showSamples = true
-  jvm = true
-  enabled = true
-}
+metrics.enabled = true
+
 
 # Microservice specific config
 
-auditing {
-  enabled = true
-  traceRequests = true
-  consumer {
-    baseUri {
-      host = localhost
-      port = 8100
-    }
-  }
-}
+auditing.enabled = true
+
 
 microservice {
-  metrics {
-    graphite {
-      host = graphite
-      port = 2003
-      prefix = play.${appName}.
-      enabled = false
-    }
-  }
 
   services {
     auth {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,20 +4,19 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % "5.25.0",
+    "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % "7.18.0",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % "0.74.0",
-    "uk.gov.hmrc"       %% "auth-client"               % "5.14.0-play-28"
+    "uk.gov.hmrc"       %% "auth-client"               % "6.1.0-play-28"
   )
 
   val test = Seq(
     "org.scalamock"                %% "scalamock"               % "5.2.0"  % "test",
-    "org.scalatest"                %% "scalatest"               % "3.1.4"  % "test",
     "com.typesafe.play"            %% "play-test"               % current  % "test",
     "uk.gov.hmrc.mongo"            %% "hmrc-mongo-test-play-28" % "0.74.0" % "test",
     "org.scalatestplus.play"       %% "scalatestplus-play"      % "5.1.0"  % "test, it",
     "com.github.tomakehurst"       %  "wiremock-jre8"           % "2.35.0" % "test, it",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"    % "2.14.1" % "test, it",
-    "uk.gov.hmrc"                  %% "bootstrap-test-play-28"  % "5.25.0" % "test, it",
-    "com.typesafe.play"            %% "play-akka-http-server"   % "2.8.18" % "test, it"
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"    % "2.15.2" % "test, it",
+    "uk.gov.hmrc"                  %% "bootstrap-test-play-28"  % "7.18.0" % "test, it",
+    "com.typesafe.play"            %% "play-akka-http-server"   % "2.8.19" % "test, it"
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")

--- a/test/base/BaseSpec.scala
+++ b/test/base/BaseSpec.scala
@@ -19,8 +19,14 @@ package base
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.libs.json._
 import play.api.i18n.Lang
+import play.api.inject.Injector
+import play.api.inject.guice.GuiceApplicationBuilder
+
+import scala.concurrent.ExecutionContext
 
 trait EnglishLanguage {
   implicit val lang: Lang = Lang("en")
@@ -102,7 +108,14 @@ trait TestConstants {
     }
 }
 
-trait BaseSpec extends AnyWordSpec with Matchers with ScalaFutures with TestConstants {
+trait BaseSpec extends AnyWordSpec with Matchers with ScalaFutures with TestConstants with GuiceOneAppPerSuite {
+
+  override lazy val app: Application = new GuiceApplicationBuilder()
+    .configure("metrics.enabled" -> "false")
+    .build()
+
+  lazy val injector: Injector = app.injector
+  implicit val ec: ExecutionContext = injector.instanceOf[ExecutionContext]
 
   def missingJsObjectAttrTests[T](jsObject: JsObject, attrsToIgnore: List[String] = Nil)(implicit objectReads: Reads[T]): Unit =
     jsObject.keys.filterNot(attrsToIgnore.contains(_)).foreach { attributeName =>

--- a/test/base/ControllerBaseSpec.scala
+++ b/test/base/ControllerBaseSpec.scala
@@ -16,20 +16,16 @@
 
 package base
 
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.inject.Injector
 import play.api.mvc.BodyParsers
 import play.api.{Configuration, Environment}
 
-trait ControllerBaseSpec extends BaseSpec with GuiceOneAppPerSuite {
+trait ControllerBaseSpec extends BaseSpec {
 
   val credential: String = "7010010"
   val name: String = "George Hudson"
   val email: String = "ghudson@emailworld.com"
 
-  lazy val injector: Injector = app.injector
-
-  lazy val config = app.injector.instanceOf[Configuration]
-  lazy val env = app.injector.instanceOf[Environment]
-  lazy val bodyParser = app.injector.instanceOf[BodyParsers.Default]
+  lazy val config = injector.instanceOf[Configuration]
+  lazy val env = injector.instanceOf[Environment]
+  lazy val bodyParser = injector.instanceOf[BodyParsers.Default]
 }

--- a/test/controllers/ApprovalControllerSpec.scala
+++ b/test/controllers/ApprovalControllerSpec.scala
@@ -16,29 +16,24 @@
 
 package controllers
 
-import models.ApprovalProcessSummary
+import base.BaseSpec
 import controllers.actions.FakeAllRolesAction
-import mocks.{MockTimescalesService, MockApprovalService}
 import core.models.errors.{BadRequestError, DuplicateKeyError, Error, InternalServerError, NotFoundError, ValidationError}
 import core.models.ocelot.errors.DuplicatePageUrl
-import models.errors.OcelotError
-import models.{ApprovalProcess, ApprovalProcessJson}
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import mocks.{MockApprovalService, MockTimescalesService}
+import models.Constants._
+import models.errors._
+import models.{ApprovalProcess, ApprovalProcessJson, ApprovalProcessSummary}
 import play.api.http.ContentTypes
 import play.api.http.Status.UNPROCESSABLE_ENTITY
-import play.api.libs.json.{JsArray, JsObject, JsValue, Json, OFormat}
+import play.api.libs.json._
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import models.ApprovalProcess
-import models.Constants._
 
 import scala.concurrent.Future
-import models.errors._
 
-class ApprovalControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with MockApprovalService with MockTimescalesService with ApprovalProcessJson {
+class ApprovalControllerSpec extends BaseSpec with MockApprovalService with MockTimescalesService with ApprovalProcessJson {
 
   private trait Test extends MockApprovalService {
     val invalidId: String = "ext95"

--- a/test/controllers/ArchivedControllerSpec.scala
+++ b/test/controllers/ArchivedControllerSpec.scala
@@ -16,23 +16,22 @@
 
 package controllers
 
-import java.time.ZonedDateTime
 import base.BaseSpec
 import controllers.actions.FakeAllRolesAction
-import mocks.MockArchiveService
-import models.{ProcessSummary, ArchivedProcess}
 import core.models.errors.{BadRequestError, InternalServerError, NotFoundError}
 import core.models.ocelot.ProcessJson
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import mocks.MockArchiveService
+import models.{ArchivedProcess, ProcessSummary}
 import play.api.http.ContentTypes
-import play.api.libs.json.JsObject
+import play.api.libs.json._
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import play.api.libs.json._
+
+import java.time.ZonedDateTime
 import scala.concurrent.Future
 
-class ArchivedControllerSpec extends BaseSpec with GuiceOneAppPerSuite with ProcessJson {
+class ArchivedControllerSpec extends BaseSpec with ProcessJson {
 
   private trait Test extends MockArchiveService {
 

--- a/test/controllers/ProcessReviewControllerSpec.scala
+++ b/test/controllers/ProcessReviewControllerSpec.scala
@@ -16,28 +16,23 @@
 
 package controllers
 
+import base.BaseSpec
 import controllers.actions.{FakeFactCheckerAction, FakeTwoEyeReviewerAction}
+import core.models.errors._
 import data.ReviewData
 import mocks.MockReviewService
+import models.Constants._
 import models._
-import core.models.errors._
-import org.scalatest.matchers.should.Matchers
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.ContentTypes
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.mvc.{AnyContentAsEmpty, Result}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import models.Constants._
 
 import scala.concurrent.Future
 
-class ProcessReviewControllerSpec extends AnyWordSpec
-  with Matchers with ScalaFutures with GuiceOneAppPerSuite with MockFactory with ReviewData with ApprovalProcessJson {
+class ProcessReviewControllerSpec extends BaseSpec with MockFactory with ReviewData with ApprovalProcessJson {
 
   private trait Test extends MockReviewService {
     val invalidId: String = "ext95"

--- a/test/controllers/PublishedControllerSpec.scala
+++ b/test/controllers/PublishedControllerSpec.scala
@@ -16,24 +16,23 @@
 
 package controllers
 
-import java.time.ZonedDateTime
 import base.BaseSpec
 import controllers.actions.FakeAllRolesAction
 import controllers.actions.FakeAllRolesAction.credential
-import mocks.{MockPublishedService, MockTimescalesService}
-import models.PublishedProcess
 import core.models.errors.{BadRequestError, InternalServerError, NotFoundError}
 import core.models.ocelot.ProcessJson
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import mocks.{MockPublishedService, MockTimescalesService}
+import models.PublishedProcess
 import play.api.http.ContentTypes
-import play.api.libs.json.{Json, JsObject}
+import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
+import java.time.ZonedDateTime
 import scala.concurrent.Future
 
-class PublishedControllerSpec extends BaseSpec with GuiceOneAppPerSuite with ProcessJson {
+class PublishedControllerSpec extends BaseSpec with ProcessJson {
 
   private trait Test extends MockPublishedService with MockTimescalesService  {
 

--- a/test/controllers/ScratchControllerSpec.scala
+++ b/test/controllers/ScratchControllerSpec.scala
@@ -16,26 +16,21 @@
 
 package controllers
 
-import java.util.UUID
-
-import mocks.MockScratchService
-import core.models.errors.{Error, BadRequestError, InternalServerError, NotFoundError, ValidationError}
+import base.BaseSpec
+import core.models.errors.{BadRequestError, Error, InternalServerError, NotFoundError, ValidationError}
 import core.models.ocelot.errors._
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import mocks.{MockScratchService, MockTimescalesService}
+import models.errors._
 import play.api.http.ContentTypes
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import models.errors._
 
+import java.util.UUID
 import scala.concurrent.Future
-import mocks.MockTimescalesService
 
-class ScratchControllerSpec extends AnyWordSpec with Matchers with ScalaFutures with GuiceOneAppPerSuite {
+class ScratchControllerSpec extends BaseSpec {
 
   private trait Test extends MockScratchService with MockTimescalesService {
     val id: String = "7a2f7eb3-6f0d-4d7f-a9b9-44a7137820ad"

--- a/test/controllers/TimescalesControllerSpec.scala
+++ b/test/controllers/TimescalesControllerSpec.scala
@@ -16,26 +16,23 @@
 
 package controllers
 
-import mocks.{MockTimescalesRepository, MockTimescalesService}
+import base.BaseSpec
 import core.models.errors.{InternalServerError, ValidationError}
+import mocks.{MockTimescalesRepository, MockTimescalesService}
 //import core.models.MongoDateTimeFormats
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import controllers.actions.FakeAllRolesAction
+import mocks.{MockApprovalService, MockPublishedService}
+import models.{TimescalesResponse, TimescalesUpdate, UpdateDetails}
 import play.api.http.ContentTypes
 import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import controllers.actions.FakeAllRolesAction
-import java.time.{ZoneId, ZonedDateTime}
-import play.api.mvc._
-import scala.concurrent.Future
-import models.{UpdateDetails, TimescalesResponse, TimescalesUpdate}
-import mocks.MockPublishedService
-import mocks.MockApprovalService
 
-class TimescalesControllerSpec extends AnyWordSpec with Matchers with ScalaFutures with GuiceOneAppPerSuite {
+import java.time.{ZoneId, ZonedDateTime}
+import scala.concurrent.Future
+
+class TimescalesControllerSpec extends BaseSpec {
 
   trait Test extends MockTimescalesService with MockTimescalesRepository with MockPublishedService with MockApprovalService {
     val timescaleJson: JsValue = Json.parse("""{"First": 1, "Second": 2, "Third": 3}""")

--- a/test/models/errors/ProcessErrorSpec.scala
+++ b/test/models/errors/ProcessErrorSpec.scala
@@ -116,11 +116,10 @@ class ProcessErrorSpec extends BaseSpec {
       val details: ErrorReport = fromGuidanceError(ErrorRedirectToFirstNonPageStanzaOnly("stanzaId"))
       details shouldBe ErrorReport("ErrorRedirectToFirstNonPageStanzaOnly: Invalid link to stanza stanzaId. Page redisplay after a ValueError must link to the first stanza after the PageStanza", "stanzaId")
     }
-    "from MissingUniqueFlowTerminator" in {
-      val details: ErrorReport = fromGuidanceError(MissingUniqueFlowTerminator("stanzaId"))
-      details shouldBe ErrorReport("MissingUniqueFlowTerminator: Flow doesn't have a unique termination page stanzaId, possible main flow connection into a sequence flow", "stanzaId")
+    "from AllFlowsMustContainMultiplePages" in {
+      val details: ErrorReport = fromGuidanceError(AllFlowsMustContainMultiplePages("stanzaId"))
+      details shouldBe ErrorReport("AllFlowsMustContainMultiplePages: Page stanzaId is reused in a flow, flows containing reused pages must contain more than one page", "stanzaId")
     }
-
     "from InvalidLabelName" in {
       val details: ErrorReport = fromGuidanceError(InvalidLabelName("stanzaId"))
       details shouldBe ErrorReport("InvalidLabelName: Invalid label name in stanza stanzaId", "stanzaId")

--- a/test/services/ApprovalServiceSpec.scala
+++ b/test/services/ApprovalServiceSpec.scala
@@ -51,8 +51,7 @@ class ApprovalServiceSpec extends BaseSpec with MockFactory {
                           mockApprovalProcessReviewRepository,
                           mockPublishedRepository,
                           new ValidatingPageBuilder(new PageBuilder(new Timescales(new DefaultTodayProvider))),
-                          mockTimescalesService,
-                          MockAppConfig)
+                          mockTimescalesService)(ec, MockAppConfig)
 
     val processReview: ApprovalProcessReview =
       ApprovalProcessReview(

--- a/test/services/ScratchServiceSpec.scala
+++ b/test/services/ScratchServiceSpec.scala
@@ -36,8 +36,7 @@ class ScratchServiceSpec extends BaseSpec {
     val pageBuilder = new ValidatingPageBuilder(new PageBuilder(new Timescales(new DefaultTodayProvider)))
     lazy val target: ScratchService = new ScratchService(mockScratchRepository,
                                                          pageBuilder,
-                                                         mockTimescalesService,
-                                                         MockAppConfig)
+                                                         mockTimescalesService)(ec, MockAppConfig)
   }
 
     "Calling save" should {

--- a/test/services/ValidatingPageBuilderSpec.scala
+++ b/test/services/ValidatingPageBuilderSpec.scala
@@ -234,8 +234,6 @@ class ValidatingPageBuilderSpec extends BaseSpec with ProcessJson {
       )
       val process = processWithLinks.copy(flow = flow)
 
-      val vertices = pageBuilder.pageBuilder.pages(process).fold(x => x, _.map(PageVertex(_)))
-
       pageBuilder.pagesWithValidation(process) match {
         case Right(pages) => fail(s"Attempt to parse page with unsupported page redirect succeeded")
         case Left(List(AllFlowsMustContainMultiplePages("3"), AllFlowsMustContainMultiplePages("5"), PageOccursInMultiplSequenceFlows("3"), PageOccursInMultiplSequenceFlows("5"), MissingTitle("3"), MissingTitle("5"), MissingTitle("7"))) => succeed
@@ -270,9 +268,7 @@ class ValidatingPageBuilderSpec extends BaseSpec with ProcessJson {
         "end" -> EndStanza
       )
       val process = processWithLinks.copy(flow = flow)
-
-      val vertices = pageBuilder.pageBuilder.pages(process).fold(x => x, _.map(PageVertex(_)))
-
+      
       pageBuilder.pagesWithValidation(process) match {
         case Right(pages) => fail(s"Attempt to parse page with unsupported page redirect succeeded")
         case Left(List(AllFlowsMustContainMultiplePages("5"), PageOccursInMultiplSequenceFlows("5"))) => succeed

--- a/test/services/ValidatingPageBuilderSpec.scala
+++ b/test/services/ValidatingPageBuilderSpec.scala
@@ -72,7 +72,8 @@ class ValidatingPageBuilderSpec extends BaseSpec with ProcessJson {
       Phrase(Vector(s"Some Text1 [link:Link to stanza 17:$pageId7]", s"Welsh, Some Text1 [link:Link to stanza 17:$pageId7]")),
       Phrase(Vector(s"Some [link:PageId3:$pageId3] Text2", s"Welsh: Some [link:PageId3:$pageId3] Text2")),
       Phrase(Vector(s"Some [link:Link to stanza 11:$pageId5] Text3", s"Welsh: Some [link:Link to stanza 11:$pageId5] Text3")),
-      Phrase(Vector("Some Text [button:HELLO:333]", "Welsh: Some Text [button:HELLO:333]"))
+      Phrase(Vector("Some Text [button:HELLO:333]", "Welsh: Some Text [button:HELLO:333]")),
+      Phrase(Vector("Some Text [button:HELLO2:5]", "Welsh: Some Text [button:HELLO2:5]"))
     )
 
     private val links = Vector(Link(0, pageId3, "", false), Link(1, pageId6, "", false), Link(2, Process.StartStanzaId, "Back to the start", false))
@@ -240,27 +241,34 @@ class ValidatingPageBuilderSpec extends BaseSpec with ProcessJson {
 
       pageBuilder.pagesWithValidation(process) match {
         case Right(pages) => fail(s"Attempt to parse page with unsupported page redirect succeeded")
-        case Left(List(PageOccursInMultiplSequenceFlows("3"), PageOccursInMultiplSequenceFlows("5"), MissingTitle("3"), MissingTitle("5"), MissingTitle("7"))) => succeed
+        case Left(List(AllFlowsMustContainMultiplePages("3"), AllFlowsMustContainMultiplePages("5"), PageOccursInMultiplSequenceFlows("3"), PageOccursInMultiplSequenceFlows("5"), MissingTitle("3"), MissingTitle("5"), MissingTitle("7"))) => succeed
         case Left(err) => fail(s"Attempt to parse page with unsupported page redirect failed with error ${err}")
       }
     }
 
-    "Detect shared pages between Sequence flows" in new Test {
+    "Detect shared pages between Sequence flows when the flows only contain one page" in new Test {
+      //should throw error for page 5, but not page 3 as that flow has more than one page
       val flow: Map[String, Stanza] = Map(
         Process.StartStanzaId -> PageStanza("/start", Seq("66"), stack = false),
         "66" -> CalloutStanza(Error, 0, Seq("111"), stack = false),
         "111" -> CalloutStanza(TypeError, 0, Seq("2"), stack = false),
         "2" -> SequenceStanza(1, Seq("3", "5", "33"), Seq(2, 3), None, stack = false),
-        "3" -> PageStanza("/page-3", Seq("4"), stack = false),
-        "4" -> InstructionStanza(0, Seq("end"), None, stack = false),
+        "3" -> PageStanza("/page-3", Seq("12"), stack = false),
+        "12" -> CalloutStanza(Title, 0, Seq("4"), stack = false),
+        "4" -> InstructionStanza(0, Seq("15"), None, stack = false),
+        "15" -> PageStanza("/page-15", Seq("10"), stack = false),
+        "10" -> CalloutStanza(Title, 0, Seq("13"), stack = false),
+        "13" -> InstructionStanza(0, Seq("end"), None, stack = false),
         "33" -> PageStanza("/page-33", Seq("44"), stack = false),
         "44" -> InstructionStanza(0, Seq("55"), None, stack = false),
         "55" -> CalloutStanza(Error, 0, Seq("11"), stack = false),
         "11" -> CalloutStanza(TypeError, 0, Seq("22"), stack = false),
         "22" -> SequenceStanza(1, Seq("3", "5", "7"), Seq(2, 3), None, stack = false),
-        "5" -> PageStanza("/page-5", Seq("6"), stack = false),
+        "5" -> PageStanza("/page-5", Seq("13"), stack = false),
+        "13" -> CalloutStanza(Title, 0, Seq("6"), stack = false),
         "6" -> InstructionStanza(0, Seq("end"), None, stack = false),
-        "7" -> PageStanza("/page-7", Seq("8"), stack = false),
+        "7" -> PageStanza("/page-7", Seq("21"), stack = false),
+        "21" -> CalloutStanza(Title, 0, Seq("8"), stack = false),
         "8" -> InstructionStanza(0, Seq("end"), None, stack = false),
         "end" -> EndStanza
       )
@@ -272,27 +280,31 @@ class ValidatingPageBuilderSpec extends BaseSpec with ProcessJson {
 
       pageBuilder.pagesWithValidation(process) match {
         case Right(pages) => fail(s"Attempt to parse page with unsupported page redirect succeeded")
-        case Left(List(PageOccursInMultiplSequenceFlows("3"), PageOccursInMultiplSequenceFlows("5"), MissingTitle("3"), MissingTitle("5"), MissingTitle("7"))) => succeed
+        case Left(List(AllFlowsMustContainMultiplePages("5"), PageOccursInMultiplSequenceFlows("5"))) => succeed
         case Left(err) => fail(s"Attempt to parse page with unsupported page redirect failed with error ${err}")
       }
     }
 
-    "Detect missing sequence flow termination caused by main flow connection into sequence flow" in new Test {
+    "Detect missing sequence flow termination caused by main flow connection into sequence flow when the sequence flow only contains one page" in new Test {
       val flow: Map[String, Stanza] = Map(
         Process.StartStanzaId -> PageStanza("/start", Seq("66"), stack = false),
         "66" -> CalloutStanza(Error, 0, Seq("111"), stack = false),
         "111" -> CalloutStanza(TypeError, 0, Seq("1"), stack = false),
-        "1" -> InstructionStanza(4, Seq("2"), None, stack = false),
+        "1" -> InstructionStanza(0, Seq("2"), None, stack = false),
         "2" -> SequenceStanza(0, Seq("3", "5", "33"), Seq(2, 3), None, stack = false),
         "3" -> PageStanza("/page-3", Seq("4"), stack = false),
         "4" -> InstructionStanza(0, Seq("333"), None, stack = false),
         "333" -> PageStanza("/page-333", Seq("444"), stack = false),
         "444" -> InstructionStanza(0, Seq("8"), None, stack = false),
         "33" -> PageStanza("/page-33", Seq("44"), stack = false),
-        "44" -> InstructionStanza(4, Seq("end"), None, stack = false),
+        "44" -> InstructionStanza(5, Seq("end"), None, stack = false),
         "5" -> PageStanza("/page-5", Seq("6"), stack = false),
         "6" -> InstructionStanza(0, Seq("end"), None, stack = false),
         "8" -> InstructionStanza(0, Seq("end"), None, stack = false),
+        "10" -> PageStanza("/page-10", Seq("12"), stack = false),
+        "12" -> InstructionStanza(0, Seq("end"), None, stack = false),
+        "7" -> PageStanza("/page-7", Seq("24"), stack = false),
+        "24" -> InstructionStanza(0, Seq("end"), None, stack = false),
         "end" -> EndStanza
       )
       val process = processWithLinks.copy(flow = flow)
@@ -303,7 +315,7 @@ class ValidatingPageBuilderSpec extends BaseSpec with ProcessJson {
 
       pageBuilder.pagesWithValidation(process) match {
         case Right(pages) => fail(s"Attempt to parse page with unsupported page redirect succeeded")
-        case Left(List(MissingUniqueFlowTerminator("3"), MissingTitle("333"), MissingTitle("3"), MissingTitle("5"), MissingTitle("33"))) => succeed
+        case Left(List(AllFlowsMustContainMultiplePages("3"), MissingUniqueFlowTerminator("3"), MissingTitle("333"), MissingTitle("3"), MissingTitle("5"), MissingTitle("33"))) => succeed
         case Left(err) => fail(s"Attempt to parse page with unsupported page redirect failed with error ${err}")
       }
     }

--- a/test/services/ValidatingPageBuilderSpec.scala
+++ b/test/services/ValidatingPageBuilderSpec.scala
@@ -236,8 +236,6 @@ class ValidatingPageBuilderSpec extends BaseSpec with ProcessJson {
 
       val vertices = pageBuilder.pageBuilder.pages(process).fold(x => x, _.map(PageVertex(_)))
 
-      println(s"\n*******\n\n$vertices\n\n******\n")
-
       pageBuilder.pagesWithValidation(process) match {
         case Right(pages) => fail(s"Attempt to parse page with unsupported page redirect succeeded")
         case Left(List(AllFlowsMustContainMultiplePages("3"), AllFlowsMustContainMultiplePages("5"), PageOccursInMultiplSequenceFlows("3"), PageOccursInMultiplSequenceFlows("5"), MissingTitle("3"), MissingTitle("5"), MissingTitle("7"))) => succeed
@@ -274,8 +272,6 @@ class ValidatingPageBuilderSpec extends BaseSpec with ProcessJson {
       val process = processWithLinks.copy(flow = flow)
 
       val vertices = pageBuilder.pageBuilder.pages(process).fold(x => x, _.map(PageVertex(_)))
-
-      println(s"\n*******\n\n$vertices\n\n******\n")
 
       pageBuilder.pagesWithValidation(process) match {
         case Right(pages) => fail(s"Attempt to parse page with unsupported page redirect succeeded")

--- a/test/services/ValidatingPageBuilderSpec.scala
+++ b/test/services/ValidatingPageBuilderSpec.scala
@@ -234,6 +234,10 @@ class ValidatingPageBuilderSpec extends BaseSpec with ProcessJson {
       )
       val process = processWithLinks.copy(flow = flow)
 
+      val vertices = pageBuilder.pageBuilder.pages(process).fold(x => x, _.map(PageVertex(_)))
+
+      println(s"\n*******\n\n$vertices\n\n******\n")
+
       pageBuilder.pagesWithValidation(process) match {
         case Right(pages) => fail(s"Attempt to parse page with unsupported page redirect succeeded")
         case Left(List(PageOccursInMultiplSequenceFlows("3"), PageOccursInMultiplSequenceFlows("5"), MissingTitle("3"), MissingTitle("5"), MissingTitle("7"))) => succeed
@@ -262,6 +266,10 @@ class ValidatingPageBuilderSpec extends BaseSpec with ProcessJson {
       )
       val process = processWithLinks.copy(flow = flow)
 
+      val vertices = pageBuilder.pageBuilder.pages(process).fold(x => x, _.map(PageVertex(_)))
+
+      println(s"\n*******\n\n$vertices\n\n******\n")
+
       pageBuilder.pagesWithValidation(process) match {
         case Right(pages) => fail(s"Attempt to parse page with unsupported page redirect succeeded")
         case Left(List(PageOccursInMultiplSequenceFlows("3"), PageOccursInMultiplSequenceFlows("5"), MissingTitle("3"), MissingTitle("5"), MissingTitle("7"))) => succeed
@@ -288,6 +296,10 @@ class ValidatingPageBuilderSpec extends BaseSpec with ProcessJson {
         "end" -> EndStanza
       )
       val process = processWithLinks.copy(flow = flow)
+
+      val vertices = pageBuilder.pageBuilder.pages(process).fold(x => x, _.map(PageVertex(_)))
+
+      println(s"\n*******\n\n$vertices\n\n******\n")
 
       pageBuilder.pagesWithValidation(process) match {
         case Right(pages) => fail(s"Attempt to parse page with unsupported page redirect succeeded")


### PR DESCRIPTION
- Added new check and error - if  pages are to be reused between flows, the flows must have more than one page
- Remove missing unique flow terminator check/error. If flows have a single page, this scenario is covered by the page reuse check, if the flow has more than one page, it no longer needs a unique terminator.
- Left hmrc mongo on 0.73 as upgrading requires reworking of the LocalDateTime formatter