### PR TITLE
DL-11616 preventing TTL warnings

### DIFF
--- a/app/repositories/ApprovalProcessReviewRepository.scala
+++ b/app/repositories/ApprovalProcessReviewRepository.scala
@@ -58,6 +58,7 @@ class ApprovalProcessReviewRepositoryImpl @Inject() (implicit mongo: MongoCompon
     )
     with ApprovalProcessReviewRepository {
   val logger: Logger = Logger(getClass)
+  override lazy val requiresTtlIndex = false
 
   def save(review: ApprovalProcessReview): Future[RequestOutcome[UUID]] =
     collection

--- a/app/repositories/ApprovalRepository.scala
+++ b/app/repositories/ApprovalRepository.scala
@@ -65,6 +65,7 @@ class ApprovalRepositoryImpl @Inject()(component: MongoComponent)(implicit appCo
     with ApprovalRepository {
 
   val logger: Logger = Logger(getClass)
+  override lazy val requiresTtlIndex = false
 
       //$COVERAGE-OFF$
 

--- a/app/repositories/ArchiveRepository.scala
+++ b/app/repositories/ArchiveRepository.scala
@@ -56,6 +56,7 @@ class ArchiveRepositoryImpl @Inject() (mongo: MongoComponent)(implicit ec: Execu
     )
     with ArchiveRepository {
   val logger: Logger = Logger(getClass)
+  override lazy val requiresTtlIndex = false
 
   def archive(id: String, user: String, processCode: String, process: PublishedProcess): Future[RequestOutcome[String]] = {
 

--- a/app/repositories/PublishedRepository.scala
+++ b/app/repositories/PublishedRepository.scala
@@ -62,6 +62,7 @@ class PublishedRepositoryImpl @Inject() (component: MongoComponent)(implicit ec:
     with PublishedRepository {
 
   val logger: Logger = Logger(getClass)
+  override lazy val requiresTtlIndex = false
 
   def save(id: String, user: String, processCode: String, process: JsObject): Future[RequestOutcome[String]] = {
 

--- a/app/repositories/TimescalesRepository.scala
+++ b/app/repositories/TimescalesRepository.scala
@@ -53,6 +53,7 @@ class TimescalesRepositoryImpl @Inject() (component: MongoComponent, appConfig: 
     )
     with TimescalesRepository {
   val logger: Logger = Logger(getClass)
+  override lazy val requiresTtlIndex: Boolean = false
 
   def save(timescales: JsValue, when: ZonedDateTime, credId: String, user: String, email: String): Future[RequestOutcome[TimescalesUpdate]] =
     collection


### PR DESCRIPTION
Adding override to repositories to specify that no TTL is required
Should prevent TTL warnings that have been showing as PD alerts 