### PR TITLE
DL-15793: dependency updates

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -19,17 +19,17 @@ import sbt.*
 object AppDependencies {
 
   val bootstrapVersion = "9.11.0"
-  val mongoPlayVersion = "2.5.0"
+  val mongoPlayVersion = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-backend-play-30" % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"        % mongoPlayVersion,
-    "uk.gov.hmrc"       %% "auth-client"               % "8.5.0",
+    "uk.gov.hmrc"       %% "auth-client"               % "8.6.0",
     "org.typelevel"     %% "cats-core"                 % "2.13.0"
   )
 
   val test: Seq[ModuleID] = Seq(
-    "org.scalamock"          %% "scalamock"               % "6.2.0",
+    "org.scalamock"          %% "scalamock"               % "7.3.0",
     "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-30" % mongoPlayVersion,
     "org.scalatestplus.play" %% "scalatestplus-play"      % "7.0.1",
     "uk.gov.hmrc"            %% "bootstrap-test-play-30"  % bootstrapVersion

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.0
+sbt.version=1.10.10


### PR DESCRIPTION
[info] Found 4 dependency updates for external-guidance
[info]   org.scalamock:scalamock:test                                    : 6.2.0          -> 7.3.0
[info]   uk.gov.hmrc.mongo:hmrc-mongo-play-30                : 2.5.0 -> 2.6.0         
[info]   uk.gov.hmrc.mongo:hmrc-mongo-test-play-30:test  : 2.5.0 -> 2.6.0         
[info]   uk.gov.hmrc:auth-client                                              : 8.5.0 -> 8.6.0   